### PR TITLE
should report not found error when data source read

### DIFF
--- a/internal/provider/clusternetwork/datasource_clusternetwork.go
+++ b/internal/provider/clusternetwork/datasource_clusternetwork.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/harvester/terraform-provider-harvester/pkg/client"
@@ -24,10 +23,6 @@ func dataSourceClusterNetworkRead(ctx context.Context, d *schema.ResourceData, m
 	name := d.Get(constants.FieldCommonName).(string)
 	clusterNetwork, err := c.HarvesterNetworkClient.NetworkV1beta1().ClusterNetworks().Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			d.SetId("")
-			return nil
-		}
 		return diag.FromErr(err)
 	}
 	return resourceClusterNetworkImport(d, clusterNetwork)

--- a/internal/provider/image/datasource_image.go
+++ b/internal/provider/image/datasource_image.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/harvester/terraform-provider-harvester/pkg/client"
@@ -25,10 +24,6 @@ func dataSourceImageRead(ctx context.Context, d *schema.ResourceData, meta inter
 	name := d.Get(constants.FieldCommonName).(string)
 	obj, err := c.HarvesterClient.HarvesterhciV1beta1().VirtualMachineImages(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			d.SetId("")
-			return nil
-		}
 		return diag.FromErr(err)
 	}
 	return resourceImageImport(d, obj)

--- a/internal/provider/keypair/datasource_keypair.go
+++ b/internal/provider/keypair/datasource_keypair.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/harvester/terraform-provider-harvester/pkg/client"
@@ -25,10 +24,6 @@ func dataSourceKeypairRead(ctx context.Context, d *schema.ResourceData, meta int
 	name := d.Get(constants.FieldCommonName).(string)
 	keyPair, err := c.HarvesterClient.HarvesterhciV1beta1().KeyPairs(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			d.SetId("")
-			return nil
-		}
 		return diag.FromErr(err)
 	}
 	return resourceKeyPairImport(d, keyPair)

--- a/internal/provider/network/datasource_network.go
+++ b/internal/provider/network/datasource_network.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/harvester/terraform-provider-harvester/pkg/client"
@@ -25,10 +24,6 @@ func dataSourceNetworkRead(ctx context.Context, d *schema.ResourceData, meta int
 	name := d.Get(constants.FieldCommonName).(string)
 	obj, err := c.HarvesterClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			d.SetId("")
-			return nil
-		}
 		return diag.FromErr(err)
 	}
 

--- a/internal/provider/virtualmachine/datasource_virtualmachine.go
+++ b/internal/provider/virtualmachine/datasource_virtualmachine.go
@@ -25,10 +25,6 @@ func dataSourceVirtualMachineRead(ctx context.Context, d *schema.ResourceData, m
 	name := d.Get(constants.FieldCommonName).(string)
 	vm, err := c.HarvesterClient.KubevirtV1().VirtualMachines(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			d.SetId("")
-			return nil
-		}
 		return diag.FromErr(err)
 	}
 	vmi, err := c.HarvesterClient.KubevirtV1().VirtualMachineInstances(namespace).Get(ctx, name, metav1.GetOptions{})

--- a/internal/provider/volume/datasource_volume.go
+++ b/internal/provider/volume/datasource_volume.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/harvester/terraform-provider-harvester/pkg/client"
@@ -25,10 +24,6 @@ func dataSourceVolumeRead(ctx context.Context, d *schema.ResourceData, meta inte
 	name := d.Get(constants.FieldCommonName).(string)
 	obj, err := c.KubeClient.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			d.SetId("")
-			return nil
-		}
 		return diag.FromErr(err)
 	}
 	return resourceVolumeImport(d, obj)


### PR DESCRIPTION
For data source, if the resource cannot be found in the cluster based on the name and namespace, an error message should be reported.

otherwise, the user might use an empty id in other resources

**Related issues**
https://github.com/harvester/harvester/issues/2461

**Test Plan**
1. create a network `vlan1` in the namespace `harvester-public` form UI side
2. create a data source harvester_network.vlan1, do not specify namespace, It will default to `default`
```hcl
data "harvester_network" "vlan1" {
  name      = "vlan1"
}
```
3. terraform apply
4. users will get an error
```
Error: network-attachment-definitions.k8s.cni.cncf.io "vlan1" not found
```
6. add correct namespace to the data source
```hcl
data "harvester_network" "vlan1" {
  name      = "vlan1"
  namespace = "harvester-public"
}
```
7. terraform apply will be success