### PR TITLE
Fix pvc.StorageClassName order

### DIFF
--- a/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
+++ b/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
@@ -191,9 +191,6 @@ func (c *Constructor) Setup() util.Processors {
 						VolumeMode: corev1.PersistentVolumeBlock,
 						AccessMode: corev1.ReadWriteMany,
 					}
-					if storageClassName := r[constants.FieldVolumeStorageClassName].(string); storageClassName != "" {
-						pvcOption.StorageClassName = pointer.StringPtr(storageClassName)
-					}
 					if volumeMode := r[constants.FieldVolumeMode].(string); volumeMode != "" {
 						pvcOption.VolumeMode = corev1.PersistentVolumeMode(volumeMode)
 					}
@@ -207,6 +204,9 @@ func (c *Constructor) Setup() util.Processors {
 						}
 						pvcOption.ImageID = helper.BuildNamespacedName(imageNamespace, imageName)
 						storageClassName := builder.BuildImageStorageClassName("", imageName)
+						pvcOption.StorageClassName = pointer.StringPtr(storageClassName)
+					}
+					if storageClassName := r[constants.FieldVolumeStorageClassName].(string); storageClassName != "" {
 						pvcOption.StorageClassName = pointer.StringPtr(storageClassName)
 					}
 					if autoDelete := r[constants.FieldDiskAutoDelete].(bool); autoDelete {

--- a/internal/provider/volume/resource_volume_constructor.go
+++ b/internal/provider/volume/resource_volume_constructor.go
@@ -76,7 +76,9 @@ func (c *Constructor) Setup() util.Processors {
 				}
 				c.Volume.Annotations[builder.AnnotationKeyImageID] = helper.BuildNamespacedName(imageNamespace, imageName)
 				storageClassName := builder.BuildImageStorageClassName("", imageName)
-				c.Volume.Spec.StorageClassName = pointer.StringPtr(storageClassName)
+				if c.Volume.Spec.StorageClassName == nil {
+					c.Volume.Spec.StorageClassName = pointer.StringPtr(storageClassName)
+				}
 				return nil
 			},
 		},


### PR DESCRIPTION
If both `storage_class_name` and `image` are provided, then `storage_class_name` gets overwritten by the one derived from the image.

This changes the order of assignment for the inline disk spec and adds a check for the volume resource, so if `storage_class_name` is provided, it doesn't get overwritten.

Tested it by building the provider locally and verifying that it creates the PVC with the correct `StorageClass`, both with specifying it and without.