### PR TITLE
Add ability to pass kubernetes context in the provider

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,3 +33,4 @@ provider "harvester" {
 ### Optional
 
 - **kubeconfig** (String) kubeconfig file path, users can use the KUBECONFIG environment variable instead
+- **kubecontext** (String) name of the kubernetes context to use

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -19,11 +19,17 @@ import (
 func Provider() *schema.Provider {
 	p := &schema.Provider{
 		Schema: map[string]*schema.Schema{
-			constants.FiledProviderKubeConfig: {
+			constants.FieldProviderKubeConfig: {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "",
 				Description: "kubeconfig file path, users can use the KUBECONFIG environment variable instead",
+			},
+			constants.FieldProviderKubeContext: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: "name of the kubernetes context to use",
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
@@ -49,8 +55,9 @@ func Provider() *schema.Provider {
 
 func configure(p *schema.Provider) schema.ConfigureContextFunc {
 	return func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
-		kubeConfig := d.Get(constants.FiledProviderKubeConfig).(string)
-		c, err := client.NewClient(kubeConfig)
+		kubeConfig := d.Get(constants.FieldProviderKubeConfig).(string)
+		kubeContext := d.Get(constants.FieldProviderKubeContext).(string)
+		c, err := client.NewClient(kubeConfig, kubeContext)
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -18,8 +18,8 @@ type Client struct {
 	HarvesterNetworkClient    *harvnetworkclient.Clientset
 }
 
-func NewClient(kubeConfig string) (*Client, error) {
-	clientConfig := kubeconfig.GetNonInteractiveClientConfig(kubeConfig)
+func NewClient(kubeConfig, kubeContext string) (*Client, error) {
+	clientConfig := kubeconfig.GetNonInteractiveClientConfigWithContext(kubeConfig, kubeContext)
 	restConfig, err := clientConfig.ClientConfig()
 	if err != nil {
 		return nil, err

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -4,7 +4,8 @@ const (
 	NamespaceDefault         = "default"
 	NamespaceHarvesterSystem = "harvester-system"
 
-	FiledProviderKubeConfig = "kubeconfig"
+	FieldProviderKubeConfig  = "kubeconfig"
+	FieldProviderKubeContext = "kubecontext"
 
 	FieldCommonName        = "name"
 	FieldCommonNamespace   = "namespace"


### PR DESCRIPTION
Add ability to pass kubernetes context in the provider.

`GetNonInteractiveClientConfig` (old) calls `GetNonInteractiveClientConfigWithContext` (new) internally with an empty context, so there's no change in behaviour there.

Renamed the constant `FiledProviderKubeConfig` as there was a typo before `Filed...` -> `Field...`