### PR TITLE
Update image volume examples and docs

### DIFF
--- a/docs/resources/image.md
+++ b/docs/resources/image.md
@@ -26,7 +26,7 @@ resource "harvester_image" "ubuntu20" {
   name      = "ubuntu20"
   namespace = "harvester-public"
 
-  display_name = "ubuntu20"
+  display_name = "ubuntu-20.04-server-cloudimg-amd64.img"
   source_type  = "download"
   url          = "http://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.img"
 }

--- a/docs/resources/volume.md
+++ b/docs/resources/volume.md
@@ -43,7 +43,7 @@ resource "harvester_volume" "ubuntu20-image-disk" {
   namespace = "default"
 
   size  = "10Gi"
-  image = "harvester-public/ubuntu20"
+  image = harvester_image.ubuntu20.id
 }
 
 resource "harvester_volume" "opensuse154-image-disk" {
@@ -51,7 +51,7 @@ resource "harvester_volume" "opensuse154-image-disk" {
   namespace = "default"
 
   size  = "10Gi"
-  image = "harvester-public/opensuse154"
+  image = harvester_image.opensuse154.id
 }
 ```
 

--- a/examples/resources/harvester_image/resource.tf
+++ b/examples/resources/harvester_image/resource.tf
@@ -11,7 +11,7 @@ resource "harvester_image" "ubuntu20" {
   name      = "ubuntu20"
   namespace = "harvester-public"
 
-  display_name = "ubuntu20"
+  display_name = "ubuntu-20.04-server-cloudimg-amd64.img"
   source_type  = "download"
   url          = "http://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.img"
 }

--- a/examples/resources/harvester_volume/resource.tf
+++ b/examples/resources/harvester_volume/resource.tf
@@ -28,7 +28,7 @@ resource "harvester_volume" "ubuntu20-image-disk" {
   namespace = "default"
 
   size  = "10Gi"
-  image = "harvester-public/ubuntu20"
+  image = harvester_image.ubuntu20.id
 }
 
 resource "harvester_volume" "opensuse154-image-disk" {
@@ -36,5 +36,5 @@ resource "harvester_volume" "opensuse154-image-disk" {
   namespace = "default"
 
   size  = "10Gi"
-  image = "harvester-public/opensuse154"
+  image = harvester_image.opensuse154.id
 }


### PR DESCRIPTION
use harvester_image id instead of image namspace/name

to make sure that the dependencies between resources are correct

