### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     harvester = {
       source  = "harvester/harvester"
-      version = "0.5.3"
+      version = "0.6.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     harvester = {
       source  = "harvester/harvester"
-      version = "0.5.3"
+      version = "0.6.0"
     }
   }
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,9 +2,12 @@ package provider
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/harvester/terraform-provider-harvester/internal/provider/clusternetwork"
 	"github.com/harvester/terraform-provider-harvester/internal/provider/image"
@@ -67,6 +70,17 @@ func configure(p *schema.Provider) schema.ConfigureContextFunc {
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}
+
+		// check harvester version from settings
+		serverVersion, err := c.HarvesterClient.HarvesterhciV1beta1().Settings().Get(context.Background(), "server-version", metav1.GetOptions{})
+		if err != nil {
+			return nil, diag.FromErr(err)
+		}
+		// harvester version v1.0-head, v1.0.2, v1.0.3 is not supported
+		if strings.HasPrefix(serverVersion.Value, "v1.0") {
+			return nil, diag.FromErr(fmt.Errorf("current Harvester server version is %s, the minimum supported version is v1.1.0", serverVersion.Value))
+		}
+
 		return c, nil
 	}
 }


### PR DESCRIPTION
1. storage tiering
- [x] new field `storage_class_name` in `harvester_image`
- [x] new resources `harvester_storageclass`
2. vlan enhancement
- [x] new field `cluster_network_name` in `harvester_network`
- [x] remove fields in `harvester_clusternetwork`
- [x] new resources `harvester_vlanconfig`
- ---

Supported Harvester Versions:

- v1.1.0



------
harvester version check before plan or apply:
```bash
7e43a613aba5:/data # terraform plan
╷
│ Error: current Harvester server version is v1.0.3, the minimum supported version is v1.1.0
│
│   with provider["registry.terraform.io/harvester/harvester"],
│   on provider.tf line 9, in provider "harvester":
│    9: provider "harvester" {
│
╵
7e43a613aba5:/data # terraform apply
╷
│ Error: current Harvester server version is v1.0.3, the minimum supported version is v1.1.0
│
│   with provider["registry.terraform.io/harvester/harvester"],
│   on provider.tf line 9, in provider "harvester":
│    9: provider "harvester" {
│
╵
```