### PR TITLE
Fix network apply error with dhcpserver

### DIFF
--- a/pkg/importer/resource_network_importer.go
+++ b/pkg/importer/resource_network_importer.go
@@ -48,10 +48,12 @@ func ResourceNetworkStateGetter(obj *nadv1.NetworkAttachmentDefinition) (*StateG
 		constants.FieldNetworkConfig:             obj.Spec.Config,
 		constants.FieldNetworkRouteMode:          layer3NetworkConf.Mode,
 		constants.FieldNetworkRouteDHCPServerIP:  layer3NetworkConf.ServerIPAddr,
-		constants.FieldNetworkRouteCIDR:          layer3NetworkConf.CIDR,
-		constants.FieldNetworkRouteGateWay:       layer3NetworkConf.Gateway,
 		constants.FieldNetworkRouteConnectivity:  layer3NetworkConf.Connectivity,
 		constants.FieldNetworkClusterNetworkName: obj.Labels[networkutils.KeyClusterNetworkLabel],
+	}
+	if layer3NetworkConf.Mode == networkutils.Manual {
+		states[constants.FieldNetworkRouteCIDR] = layer3NetworkConf.CIDR
+		states[constants.FieldNetworkRouteGateWay] = layer3NetworkConf.Gateway
 	}
 	return &StateGetter{
 		ID:           helper.BuildID(obj.Namespace, obj.Name),


### PR DESCRIPTION
Signed-off-by: futuretea <Hang.Yu@suse.com>

**Related issues**
https://github.com/harvester/harvester/issues/2857

**Test plan**

- Setup test env by https://github.com/harvester/terraform-provider-harvester/wiki/PR-Test-Env-Setup for `Reviwer`
- Setup test env by https://github.com/harvester/terraform-provider-harvester/wiki/Use-the-master-head-docker-image-for-testing for `Tester`
- Create a test config file
```bash
vim main.tf
```
**Network**
- Add resource `harvester_network` with `route_mode = "auto"` and `route_dhcp_server_ip = "<replace to your dhcp server>"`
```hcl
resource "harvester_network" "mgmt-vlan1" {
  name      = "mgmt-vlan1"
  namespace = "harvester-public"

  vlan_id = 1

  route_mode           = "auto"
  route_dhcp_server_ip = "192.168.5.1"

  cluster_network_name = "mgmt"
}
```
- apply 
```bash
terraform apply -auto-approve
```
- apply again
```bash
terraform apply -auto-approve
```