### PR TITLE
feat(vm): support resize pvc

### DIFF
--- a/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
+++ b/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
@@ -199,14 +199,14 @@ func (c *Constructor) Setup() util.Processors {
 					// storageClass
 					storageClassName := r[constants.FieldVolumeStorageClassName].(string)
 					if imageNamespacedName != "" {
+						imageNamespace, imageName, err := helper.NamespacedNamePartsByDefault(imageNamespacedName, c.Builder.VirtualMachine.Namespace)
+						if err != nil {
+							return err
+						}
 						if storageClassName == "" {
-							imageNamespace, imageName, err := helper.NamespacedNamePartsByDefault(imageNamespacedName, c.Builder.VirtualMachine.Namespace)
-							if err != nil {
-								return err
-							}
 							pvcOption.ImageID = helper.BuildNamespacedName(imageNamespace, imageName)
 							storageClassName = builder.BuildImageStorageClassName("", imageName)
-						} else {
+						} else if storageClassName != builder.BuildImageStorageClassName("", imageName) {
 							return fmt.Errorf("the %s of an image can only be defined during image creation", constants.FieldVolumeStorageClassName)
 						}
 					} else {


### PR DESCRIPTION
ref: https://github.com/harvester/harvester/issues/2810
rely on: https://github.com/harvester/harvester/pull/3191

### Test plan

1. Create a Harvester cluster.
2. Follow this document to setup terraform environment. https://github.com/harvester/terraform-provider-harvester/wiki/PR-Test-Env-Setup
3. Create a file `main.tf` and add following content.
```tf
resource "harvester_image" "ubuntu20" {
  name      = "ubuntu20"
  namespace = "default"

  display_name = "ubuntu-20.04-server-cloudimg-amd64.img"
  source_type  = "download"
  url          = "http://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.img"
}

resource "harvester_virtualmachine" "ubuntu20" {
  name                 = "ubuntu20"
  namespace            = "default"
  restart_after_update = true

  description = "test ubuntu20 raw image"
  tags = {
    ssh-user = "ubuntu"
  }

  cpu    = 2
  memory = "2Gi"

  efi         = true
  secure_boot = true

  run_strategy = "RerunOnFailure"
  hostname     = "ubuntu20"
  machine_type = "q35"

  network_interface {
    name           = "nic-1"
    wait_for_lease = true
  }

  disk {
    name       = "rootdisk"
    type       = "disk"
    size       = "10Gi"
    bus        = "virtio"
    boot_order = 1

    image       = harvester_image.ubuntu20.id
    auto_delete = true
  }

  cloudinit {
    user_data    = <<-EOF
      #cloud-config
      password: test
      chpasswd:
        expire: false
      ssh_pwauth: true
      package_update: true
      packages:
        - qemu-guest-agent
      runcmd:
        - - systemctl
          - enable
          - '--now'
          - qemu-guest-agent
      EOF
    network_data = ""
  }
}
```
4. Run `terraform apply`. We should get a VMImage and a VM.
5. Change `run_strategy` to `Halted` and `size` to `20Gi`.
6. Run `terraform apply`. In the Volumes page, we can see the disk of VM is changed to `20Gi`.
7. In the Virtual Machines page, start the VM again. VM can be started successfully without error.