### PR TITLE
[backport v1.0]Fix network apply error with dhcpserver

### DIFF
--- a/internal/provider/network/resource_network_constructor.go
+++ b/internal/provider/network/resource_network_constructor.go
@@ -109,9 +109,7 @@ func (c *Constructor) Setup() util.Processors {
 				if _, err = networkutils.NewLayer3NetworkConf(layer3NetworkConf); err != nil {
 					return err
 				}
-				c.Network.Annotations = map[string]string{
-					networkutils.KeyNetworkConf: layer3NetworkConf,
-				}
+				c.Network.Annotations[networkutils.KeyNetworkConf] = layer3NetworkConf
 				return nil
 			},
 			Required: true,

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.3
+FROM registry.suse.com/bci/bci-base:15.4
 
 # hadolint ignore=DL3037
 RUN zypper -n rm container-suseconnect && \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,7 +1,8 @@
 FROM registry.suse.com/bci/bci-base:15.3
 
+# hadolint ignore=DL3037
 RUN zypper -n rm container-suseconnect && \
-    zypper -n install unzip=6.00 curl=7.66.0 vim=9.0.0313 && \
+    zypper -n install unzip curl vim && \
     zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/*
 
 ARG ARCH=amd64

--- a/pkg/importer/resource_network_importer.go
+++ b/pkg/importer/resource_network_importer.go
@@ -49,9 +49,11 @@ func ResourceNetworkStateGetter(obj *nadv1.NetworkAttachmentDefinition) (*StateG
 		constants.FieldNetworkConfig:            obj.Spec.Config,
 		constants.FieldNetworkRouteMode:         layer3NetworkConf.Mode,
 		constants.FieldNetworkRouteDHCPServerIP: layer3NetworkConf.ServerIPAddr,
-		constants.FieldNetworkRouteCIDR:         layer3NetworkConf.CIDR,
-		constants.FieldNetworkRouteGateWay:      layer3NetworkConf.Gateway,
 		constants.FieldNetworkRouteConnectivity: layer3NetworkConf.Connectivity,
+	}
+	if layer3NetworkConf.Mode == networkutils.Manual {
+		states[constants.FieldNetworkRouteCIDR] = layer3NetworkConf.CIDR
+		states[constants.FieldNetworkRouteGateWay] = layer3NetworkConf.Gateway
 	}
 	return &StateGetter{
 		ID:           helper.BuildID(obj.Namespace, obj.Name),


### PR DESCRIPTION
Signed-off-by: futuretea <Hang.Yu@suse.com>

backport
https://github.com/harvester/terraform-provider-harvester/pull/60
https://github.com/harvester/terraform-provider-harvester/pull/66
https://github.com/harvester/terraform-provider-harvester/pull/68

**Related issues**
https://github.com/harvester/harvester/issues/3284

**Test plan**
- Prepare a v1.0.3 Harvester cluster
- Enable cluster network
- Setup test env by https://github.com/harvester/terraform-provider-harvester/wiki/PR-Test-Env-Setup for `Reviwer`
or Setup test env by https://github.com/harvester/terraform-provider-harvester/wiki/Use-the-prebuilt-docker-image-for-testing for `Tester` (need to change BRANCH to v1.0)
- Create a test config file
```bash
vim main.tf
```
**Network**
- Add resource `harvester_network` with `route_mode = "auto"` and `route_dhcp_server_ip = "<replace to your dhcp server>"`
```hcl
resource "harvester_network" "vlan1" {
  name      = "vlan1"
  namespace = "harvester-public"
  description = ""

  vlan_id = 1

  route_mode           = "auto"
  route_dhcp_server_ip = "192.168.5.1"
}
```
- apply 
```bash
terraform apply -auto-approve
```
- change description and apply again
```bash
vim main.tf
terraform apply -auto-approve
```