### PR TITLE
Add the ability to provide reserved_memory annotation field in virtual machine

### DIFF
--- a/docs/data-sources/virtualmachine.md
+++ b/docs/data-sources/virtualmachine.md
@@ -49,6 +49,7 @@ data "harvester_virtualmachine" "opensuse154" {
 - **message** (String)
 - **network_interface** (List of Object) (see [below for nested schema](#nestedatt--network_interface))
 - **node_name** (String)
+- **reserved_memory** (String)
 - **restart_after_update** (Boolean) restart vm after the vm is updated
 - **run_strategy** (String) more info: https://kubevirt.io/user-guide/virtual_machines/run_strategies/
 - **secure_boot** (Boolean) EFI must be enabled to use this feature

--- a/docs/resources/virtualmachine.md
+++ b/docs/resources/virtualmachine.md
@@ -71,9 +71,10 @@ resource "harvester_virtualmachine" "ubuntu20" {
   efi         = true
   secure_boot = true
 
-  run_strategy = "RerunOnFailure"
-  hostname     = "ubuntu20"
-  machine_type = "q35"
+  run_strategy    = "RerunOnFailure"
+  hostname        = "ubuntu20"
+  reserved_memory = "100Mi"
+  machine_type    = "q35"
 
   network_interface {
     name           = "nic-1"
@@ -228,6 +229,7 @@ resource "harvester_virtualmachine" "opensuse154" {
 - **machine_type** (String)
 - **memory** (String)
 - **namespace** (String)
+- **reserved_memory** (String)
 - **restart_after_update** (Boolean) restart vm after the vm is updated
 - **run_strategy** (String) more info: https://kubevirt.io/user-guide/virtual_machines/run_strategies/
 - **secure_boot** (Boolean) EFI must be enabled to use this feature

--- a/examples/resources/harvester_virtualmachine/resource.tf
+++ b/examples/resources/harvester_virtualmachine/resource.tf
@@ -56,9 +56,10 @@ resource "harvester_virtualmachine" "ubuntu20" {
   efi         = true
   secure_boot = true
 
-  run_strategy = "RerunOnFailure"
-  hostname     = "ubuntu20"
-  machine_type = "q35"
+  run_strategy    = "RerunOnFailure"
+  hostname        = "ubuntu20"
+  reserved_memory = "100Mi"
+  machine_type    = "q35"
 
   network_interface {
     name           = "nic-1"

--- a/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
+++ b/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
@@ -123,6 +123,15 @@ func (c *Constructor) Setup() util.Processors {
 			},
 		},
 		{
+			Field: constants.FieldVirtualMachineReservedMemory,
+			Parser: func(i interface{}) error {
+				vmBuilder.Annotations(map[string]string{
+					harvesterutil.AnnotationReservedMemory: i.(string),
+				})
+				return nil
+			},
+		},
+		{
 			Field: constants.FieldVirtualMachineSSHKeys,
 			Parser: func(i interface{}) error {
 				sshKey := i.(string)

--- a/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
+++ b/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
@@ -128,7 +128,7 @@ func (c *Constructor) Setup() util.Processors {
 				reservedMemory := i.(string)
 				if reservedMemory != "" {
 					vmBuilder.Annotations(map[string]string{
-						harvesterutil.AnnotationReservedMemory: i.(string),
+						harvesterutil.AnnotationReservedMemory: reservedMemory,
 					})
 				} else {
 					delete(vmBuilder.VirtualMachine.Annotations, harvesterutil.AnnotationReservedMemory)

--- a/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
+++ b/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
@@ -125,11 +125,17 @@ func (c *Constructor) Setup() util.Processors {
 		{
 			Field: constants.FieldVirtualMachineReservedMemory,
 			Parser: func(i interface{}) error {
-				vmBuilder.Annotations(map[string]string{
-					harvesterutil.AnnotationReservedMemory: i.(string),
-				})
+				reservedMemory := i.(string)
+				if reservedMemory != "" {
+					vmBuilder.Annotations(map[string]string{
+						harvesterutil.AnnotationReservedMemory: i.(string),
+					})
+				} else {
+					delete(vmBuilder.VirtualMachine.Annotations, harvesterutil.AnnotationReservedMemory)
+				}
 				return nil
 			},
+			Required: true,
 		},
 		{
 			Field: constants.FieldVirtualMachineSSHKeys,

--- a/internal/provider/virtualmachine/schema_virtualmachine.go
+++ b/internal/provider/virtualmachine/schema_virtualmachine.go
@@ -26,7 +26,6 @@ func Schema() map[string]*schema.Schema {
 		constants.FieldVirtualMachineReservedMemory: {
 			Type:     schema.TypeString,
 			Optional: true,
-			Computed: true,
 		},
 		constants.FieldVirtualMachineRestartAfterUpdate: {
 			Type:        schema.TypeBool,

--- a/internal/provider/virtualmachine/schema_virtualmachine.go
+++ b/internal/provider/virtualmachine/schema_virtualmachine.go
@@ -23,6 +23,11 @@ func Schema() map[string]*schema.Schema {
 			Optional: true,
 			Computed: true,
 		},
+		constants.FieldVirtualMachineReservedMemory: {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
 		constants.FieldVirtualMachineRestartAfterUpdate: {
 			Type:        schema.TypeBool,
 			Optional:    true,

--- a/pkg/constants/constants_virtualmachine.go
+++ b/pkg/constants/constants_virtualmachine.go
@@ -5,6 +5,7 @@ const (
 
 	FieldVirtualMachineMachineType        = "machine_type"
 	FieldVirtualMachineHostname           = "hostname"
+	FieldVirtualMachineReservedMemory     = "reserved_memory"
 	FieldVirtualMachineRestartAfterUpdate = "restart_after_update"
 	FieldVirtualMachineStart              = "start"
 	FieldVirtualMachineRunStrategy        = "run_strategy"

--- a/pkg/importer/resource_virtualmachine_importer.go
+++ b/pkg/importer/resource_virtualmachine_importer.go
@@ -34,6 +34,10 @@ func (v *VMImporter) HostName() string {
 	return v.VirtualMachine.Spec.Template.Spec.Hostname
 }
 
+func (v *VMImporter) ReservedMemory() string {
+	return v.VirtualMachine.Annotations[harvesterutil.AnnotationReservedMemory]
+}
+
 func (v *VMImporter) Description() string {
 	return v.VirtualMachine.Annotations[builder.AnnotationKeyDescription]
 }
@@ -336,6 +340,7 @@ func ResourceVirtualMachineStateGetter(vm *kubevirtv1.VirtualMachine, vmi *kubev
 			constants.FieldVirtualMachineCPU:              vmImporter.CPU(),
 			constants.FieldVirtualMachineMemory:           vmImporter.Memory(),
 			constants.FieldVirtualMachineHostname:         vmImporter.HostName(),
+			constants.FieldVirtualMachineReservedMemory:   vmImporter.ReservedMemory(),
 			constants.FieldVirtualMachineMachineType:      vmImporter.MachineType(),
 			constants.FieldVirtualMachineRunStrategy:      string(runStrategy),
 			constants.FieldVirtualMachineNetworkInterface: networkInterface,


### PR DESCRIPTION
  
![image](https://user-images.githubusercontent.com/29251855/215999997-de5b58c3-0ea4-4124-b3fc-83dd385297ad.png)


#### Related issues 
https://github.com/harvester/harvester/issues/3402

#### Test plan 
* Setup test env by https://github.com/harvester/terraform-provider-harvester/wiki/PR-Test-Env-Setup for `Reviwer`
* Setup test env by https://github.com/harvester/terraform-provider-harvester/wiki/Use-the-master-head-docker-image-for-testing for `Tester`

* Create a test config file in the test container 
  ```
  resource "harvester_image" "ubuntu20" {
    name      = "ubuntu20"
    namespace = "harvester-public"
  
    display_name = "ubuntu-20.04-server-cloudimg-amd64.img"
    source_type  = "download"
    url          = "http://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.img"
  }
  
  resource "harvester_virtualmachine" "ubuntu20" {
    name                 = "ubuntu20"
    namespace            = "default"
    restart_after_update = true
  
    description = "test ubuntu20 raw image"
    tags = {
      ssh-user = "ubuntu"
    }
  
    cpu    = 2
    memory = "2Gi"
  
    efi         = true
    secure_boot = true
  
    run_strategy    = "RerunOnFailure"
    hostname        = "ubuntu20"
    reserved_memory = "100Mi"
    machine_type    = "q35"
  
    network_interface {
      name           = "nic-1"
      wait_for_lease = true
    }
  
    disk {
      name       = "rootdisk"
      type       = "disk"
      size       = "10Gi"
      bus        = "virti
  
  ```

* Apply the resource 
  ```
  terraform apply -auto-approve
  ```
  
* Check the reserved memory filed value can be added in VM config page

