### PR TITLE
Update list of OS and ARCH to target

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,11 +16,18 @@ builds:
   ldflags:
     - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
   goos:
+    - freebsd
+    - windows
     - linux
     - darwin
   goarch:
     - amd64
+    - '386'
+    - arm
     - arm64
+  ignore:
+    - goos: darwin
+      goarch: '386'
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip


### PR DESCRIPTION
The current terraform-provider-scaffolding repository offers builds for Freebsd, Windows, Linux, and Darwin.

In my particular case, I'm running on Windows, and currently get an error message of 
> Provider registry.terraform.io/harvester/harvester v0.6.1 does not have a package available for your current platform, windows_amd64.

