### PR TITLE
Allow -1 value for bond_miimon uplink bond option

### DIFF
--- a/internal/provider/vlanconfig/schema_vlanconfig_uplink.go
+++ b/internal/provider/vlanconfig/schema_vlanconfig_uplink.go
@@ -34,7 +34,7 @@ func resourceUplinkSchema() map[string]*schema.Schema {
 		constants.FieldUplinkBondMiimon: {
 			Type:         schema.TypeInt,
 			Optional:     true,
-			ValidateFunc: validation.IntAtLeast(0),
+			ValidateFunc: validation.IntAtLeast(-1),
 			Description:  "refer to https://www.kernel.org/doc/Documentation/networking/bonding.txt",
 		},
 		constants.FieldUplinkMTU: {


### PR DESCRIPTION
While not a valid option per the Kernel's documentation, Harvester uses -1 as a special value to preserve whatever the current value is. If -1 is not allowed and the option is simply omitted for the vlanconfig, the Terraform provider will always show a change of the state from -1 to "null" at every run.

The vlanconfig cannot be changed without stopping all the VM instances using it, which is why it would be useful to allow the special value that preserves the existing configuration.