### PR TITLE
Add resource definition for backup targets 

### DIFF
--- a/examples/resources/harvester_backup_target/resource.tf
+++ b/examples/resources/harvester_backup_target/resource.tf
@@ -1,0 +1,10 @@
+resource "harvester_backup_target" "cloudflare-r2" {
+  name = "cloudflare-r2"
+  type = "s3"
+  endpoint_url = "https://324293h49ugfwgwr.r2.cloudflarestorage.com"
+  access_key = "a99454f829b7a73049f042360b125493"
+  secret_access_key = "8316e1a2d71e7e63af82373140d1c3cec86346c454f60207024cd7030a186fe5"
+  bucket_name = "vm-backups"
+  bucket_region = "auto"
+  virtual_hosted = false
+}


### PR DESCRIPTION
harvesterhci.io.setting provides a `backup-target` configuration within the user interface and (consequently) the Harvester API.  This is an example terraform resource definition for adding configuration support for `backup-target`.  This resource is not currently available in the harvester TF provider.

Would be a nice enhancement for a future release!