### PR TITLE
ci: fix go version with quote for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: '1.20'
       -
         name: Import GPG key
         id: import_gpg


### PR DESCRIPTION
Without quote, CI think 1.20 as 1.2.

Ref: https://github.com/harvester/terraform-provider-harvester/actions/runs/7296020228/job/19883228070