### PR TITLE
fix: add UntaggedNetwork and remove NetworkTypeCustom 

### DIFF
--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -3,7 +3,7 @@
 page_title: "harvester_network Resource - terraform-provider-harvester"
 subcategory: ""
 description: |-
-  
+
 ---
 
 # harvester_network (Resource)
@@ -13,6 +13,18 @@ description: |-
 ## Example Usage
 
 ```terraform
+resource "harvester_network" "mgmt-untagged-network" {
+  name      = "mgmt-untagged-network"
+  namespace = "harvester-public"
+
+  vlan_id = 0
+
+  route_mode           = "auto"
+  route_dhcp_server_ip = ""
+
+  cluster_network_name = data.harvester_clusternetwork.mgmt.name
+}
+
 resource "harvester_network" "mgmt-vlan1" {
   name      = "mgmt-vlan1"
   namespace = "harvester-public"

--- a/internal/provider/network/schema_network.go
+++ b/internal/provider/network/schema_network.go
@@ -14,8 +14,8 @@ func Schema() map[string]*schema.Schema {
 		constants.FieldNetworkVlanID: {
 			Type:         schema.TypeInt,
 			Required:     true,
-			ValidateFunc: validation.IntBetween(1, 4094),
-			Description:  "e.g. 1-4094",
+			ValidateFunc: validation.IntBetween(0, 4094),
+			Description:  "e.g. 0-4094",
 		},
 		constants.FieldNetworkConfig: {
 			Type:     schema.TypeString,
@@ -23,9 +23,10 @@ func Schema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		constants.FieldNetworkClusterNetworkName: {
-			Type:        schema.TypeString,
-			Required:    true,
-			Description: "", //TODO
+			Type:         schema.TypeString,
+			Required:     true,
+			Description:  "", //TODO
+			ValidateFunc: validation.StringIsNotEmpty,
 		},
 		constants.FieldNetworkRouteMode: {
 			Type:     schema.TypeString,

--- a/internal/tests/resource_network_test.go
+++ b/internal/tests/resource_network_test.go
@@ -50,8 +50,8 @@ func TestAccNetwork_basic(t *testing.T) {
 		CheckDestroy: testAccCheckNetworkDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config:      buildNetworkConfig(testAccNetworkName, testAccNetworkDescription, "0"),
-				ExpectError: regexp.MustCompile(fmt.Sprintf(`expected %s to be in the range \(1 - 4094\)`, constants.FieldNetworkVlanID)),
+				Config:      buildNetworkConfig(testAccNetworkName, testAccNetworkDescription, "4045"),
+				ExpectError: regexp.MustCompile(fmt.Sprintf(`expected %s to be in the range \(0 - 4094\)`, constants.FieldNetworkVlanID)),
 			},
 			{
 				Config: buildNetworkConfig(testAccNetworkName, testAccNetworkDescription, testAccNetworkVlanID),


### PR DESCRIPTION
issue: https://github.com/harvester/harvester/issues/5226

### Test

Setup: Create a Harvester cluster

Case 1: new terraform provider
1. Build terraform-harvester-provider.
```
CGO_ENABLED=0 go build -mod=vendor -o bin/terraform-provider-harvester .
mkdir -p ~/.terraform.d/plugins/registry.terraform.io/harvester/harvester/0.0.0-dev/linux_amd64
cp bin/terraform-provider-harvester ~/.terraform.d/plugins/registry.terraform.io/harvester/harvester/0.0.0-dev/linux_amd64/terraform-provider-harvester_v0.0.0-dev
```
2. Create a temporary folder and put the following content in `versions.tf`.

```terraform
terraform {
  required_providers {
    harvester = {
      source  = "harvester/harvester"
      /* version = "0.6.4" */
      version = "0.0.0-dev"
    }
  }
}

provider "harvester" {
  kubeconfig = "~/.kube/config"
}
```

3. Put the following content in `main.tf` in the temporary folder.

```terraform
data "harvester_clusternetwork" "mgmt" {
  name = "mgmt"
}

resource "harvester_network" "mgmt-untagged-network" {
  name      = "mgmt-untagged-network"
  namespace = "harvester-public"

  vlan_id = 0

  route_mode           = "auto"
  route_dhcp_server_ip = ""

  cluster_network_name = data.harvester_clusternetwork.mgmt.name
}

resource "harvester_network" "mgmt-vlan1" {
  name      = "mgmt-vlan1"
  namespace = "harvester-public"

  vlan_id = 1

  route_mode           = "auto"
  route_dhcp_server_ip = ""

  cluster_network_name = data.harvester_clusternetwork.mgmt.name
}
```

4. Run `terraform init` and `terraform apply`. There are two VM Networks without error.
5. Run `terraform destroy` to remove all data.

Case 2: Upgrade path

1. Create a temporary folder and put the following content in `versions.tf`.

```terraform
terraform {
  required_providers {
    harvester = {
      source  = "harvester/harvester"
      version = "0.6.4"
      /* version = "0.0.0-dev" */
    }
  }
}

provider "harvester" {
  kubeconfig = "~/.kube/config"
}
```
2. Put the following content in `main.tf` in the temporary folder.

```terraform
data "harvester_clusternetwork" "mgmt" {
  name = "mgmt"
}

resource "harvester_network" "mgmt-vlan1" {
  name      = "mgmt-vlan1"
  namespace = "harvester-public"

  vlan_id = 1

  route_mode           = "auto"
  route_dhcp_server_ip = ""

  cluster_network_name = data.harvester_clusternetwork.mgmt.name
}
```

3. Run `terraform init` and `terraform apply`. There is one VM Networks without error.
4. Build terraform-harvester-provider.
```
CGO_ENABLED=0 go build -mod=vendor -o bin/terraform-provider-harvester .
mkdir -p ~/.terraform.d/plugins/registry.terraform.io/harvester/harvester/0.0.0-dev/linux_amd64
cp bin/terraform-provider-harvester ~/.terraform.d/plugins/registry.terraform.io/harvester/harvester/0.0.0-dev/linux_amd64/terraform-provider-harvester_v0.0.0-dev
```
5. Update `versions.tf` to use `0.0.0-dev`.
6. Run `terraform init --upgrade` and `terraform apply`. No change happen.
```
data.harvester_clusternetwork.mgmt: Reading...
data.harvester_clusternetwork.mgmt: Read complete after 0s [id=mgmt]
harvester_network.mgmt-vlan1: Refreshing state... [id=harvester-public/mgmt-vlan1]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```