### PR TITLE
fix: get storage class name from vmimage status

### DIFF
--- a/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
+++ b/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
@@ -218,8 +218,12 @@ func (c *Constructor) Setup() util.Processors {
 						if err != nil {
 							return err
 						}
+						vmimage, err := c.Client.HarvesterClient.HarvesterhciV1beta1().VirtualMachineImages(imageNamespace).Get(c.Context, imageName, metav1.GetOptions{})
+						if err != nil {
+							return err
+						}
 						pvcOption.ImageID = helper.BuildNamespacedName(imageNamespace, imageName)
-						scName := builder.BuildImageStorageClassName("", imageName)
+						scName := vmimage.Status.StorageClassName
 						if storageClassName == "" {
 							storageClassName = scName
 						} else if storageClassName != scName {


### PR DESCRIPTION
issue: https://github.com/harvester/harvester/issues/5165

1. Build terraform-harvester-provider.
```bash
CGO_ENABLED=0 go build -mod=vendor -o bin/terraform-provider-harvester .
mkdir -p ~/.terraform.d/plugins/registry.terraform.io/harvester/harvester/0.0.0-dev/linux_amd64
cp bin/terraform-provider-harvester ~/.terraform.d/plugins/registry.terraform.io/harvester/harvester/0.0.0-dev/linux_amd64/terraform-provider-harvester_v0.0.0-dev
```

2. Create a temporary folder and put the following content in `versions.tf`.

```terraform
terraform {
  required_providers {
    harvester = {
      source  = "harvester/harvester"
      /* version = "0.6.4" */
      version = "0.0.0-dev"
    }
  }
}

provider "harvester" {
  kubeconfig = "~/.kube/config"
}
```

3. Put the following content in `main.tf` in the temporary folder.

```terraform
resource "harvester_image" "ubuntu20" {
   name      = "ubuntu-focal"
   namespace = "default"

   display_name = "ubuntu-focal"
   source_type  = "download"
   url          = "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img"
 }

resource "harvester_cloudinit_secret" "cloud-config-ubuntu20" {
  name      = "cloud-config-ubuntu20"
  namespace = "default"

  user_data    = <<-EOF
    #cloud-config
    password: test
    chpasswd:
      expire: false
    ssh_pwauth: true
    package_update: true
    packages:
      - qemu-guest-agent
    runcmd:
      - - systemctl
        - enable
        - '--now'
        - qemu-guest-agent
    EOF
  network_data = ""
}

resource "harvester_virtualmachine" "ubuntu20" {
  name                 = "ubuntu20"
  namespace            = "default"
  restart_after_update = true

  description = "test ubuntu20 raw image"
  tags = {
    ssh-user = "ubuntu"
  }

  cpu    = 1
  memory = "2Gi"

  run_strategy    = "RerunOnFailure"
  hostname        = "ubuntu20"
  reserved_memory = "100Mi"
  machine_type    = "q35"

  network_interface {
    name           = "nic-1"
    wait_for_lease = true
  }

  disk {
    name       = "rootdisk"
    type       = "disk"
    size       = "10Gi"
    bus        = "virtio"
    boot_order = 1

    image       = harvester_image.ubuntu20.id
    auto_delete = true
  }

  cloudinit {
    user_data_secret_name    = harvester_cloudinit_secret.cloud-config-ubuntu20.name
    network_data_secret_name = harvester_cloudinit_secret.cloud-config-ubuntu20.name
  }
}
```

4. Run `terraform init` and `terraform apply` without error.