### PR TITLE
Add timeouts for image resource

### DIFF
--- a/internal/provider/image/resource_image.go
+++ b/internal/provider/image/resource_image.go
@@ -29,6 +29,11 @@ func ResourceImage() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: Schema(),
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+		},
 	}
 }
 


### PR DESCRIPTION
Add defaults for create, delete and update in order to be able to override them when defining an image resource.