### PR TITLE
Add timeout blocks for Terraform resources

### DIFF
--- a/internal/provider/cloudinitsecret/resource_cloudinitsecret.go
+++ b/internal/provider/cloudinitsecret/resource_cloudinitsecret.go
@@ -3,9 +3,12 @@ package cloudinitsecret
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -28,6 +31,13 @@ func ResourceCloudInitSecret() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: Schema(),
+		Timeouts: &schema.ResourceTimeout{
+			Create:  schema.DefaultTimeout(2 * time.Minute),
+			Read:    schema.DefaultTimeout(2 * time.Minute),
+			Update:  schema.DefaultTimeout(2 * time.Minute),
+			Delete:  schema.DefaultTimeout(2 * time.Minute),
+			Default: schema.DefaultTimeout(2 * time.Minute),
+		},
 	}
 }
 
@@ -100,6 +110,19 @@ func resourceCloudInitSecretDelete(ctx context.Context, d *schema.ResourceData, 
 	if err != nil && !apierrors.IsNotFound(err) {
 		return diag.FromErr(err)
 	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{constants.StateImageTerminating, constants.StateCommonActive},
+		Target:     []string{constants.StateCommonRemoved},
+		Refresh:    resourceCloudInitSecretRefresh(ctx, d, meta),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
+		Delay:      1 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	d.SetId("")
 	return nil
 }
@@ -128,4 +151,31 @@ func resourceCloudInitSecretImport(d *schema.ResourceData, obj *corev1.Secret) e
 	}
 
 	return util.ResourceStatesSet(d, stateGetter)
+}
+
+func resourceCloudInitSecretRefresh(ctx context.Context, d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		c := meta.(*client.Client)
+		namespace := d.Get(constants.FieldCommonNamespace).(string)
+		name := d.Get(constants.FieldCommonName).(string)
+
+		obj, err := c.KubeClient.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return obj, constants.StateCommonRemoved, nil
+			}
+			return obj, constants.StateCommonError, err
+		}
+
+		if err = resourceCloudInitSecretImport(d, obj); err != nil {
+			return obj, constants.StateCommonError, err
+		}
+
+		state := d.Get(constants.FieldCommonState).(string)
+		if state == constants.StateCommonFailed {
+			message := d.Get(constants.FieldCommonMessage).(string)
+			return obj, state, errors.New(message)
+		}
+		return obj, state, err
+	}
 }

--- a/internal/provider/clusternetwork/resource_clusternetwork.go
+++ b/internal/provider/clusternetwork/resource_clusternetwork.go
@@ -3,6 +3,7 @@ package clusternetwork
 import (
 	"context"
 	"fmt"
+	"time"
 
 	harvsternetworkv1 "github.com/harvester/harvester-network-controller/pkg/apis/network.harvesterhci.io/v1beta1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -27,6 +28,13 @@ func ResourceClusterNetwork() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: Schema(),
+		Timeouts: &schema.ResourceTimeout{
+			Create:  schema.DefaultTimeout(2 * time.Minute),
+			Read:    schema.DefaultTimeout(2 * time.Minute),
+			Update:  schema.DefaultTimeout(2 * time.Minute),
+			Delete:  schema.DefaultTimeout(2 * time.Minute),
+			Default: schema.DefaultTimeout(2 * time.Minute),
+		},
 	}
 }
 

--- a/internal/provider/keypair/resource_keypair.go
+++ b/internal/provider/keypair/resource_keypair.go
@@ -2,6 +2,7 @@ package keypair
 
 import (
 	"context"
+	"time"
 
 	harvsterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -26,6 +27,13 @@ func ResourceKeypair() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: Schema(),
+		Timeouts: &schema.ResourceTimeout{
+			Create:  schema.DefaultTimeout(2 * time.Minute),
+			Read:    schema.DefaultTimeout(2 * time.Minute),
+			Update:  schema.DefaultTimeout(2 * time.Minute),
+			Delete:  schema.DefaultTimeout(2 * time.Minute),
+			Default: schema.DefaultTimeout(2 * time.Minute),
+		},
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -61,34 +61,35 @@ func Provider() *schema.Provider {
 			constants.ResourceTypeVLANConfig:      vlanconfig.ResourceVLANConfig(),
 			constants.ResourceTypeCloudInitSecret: cloudinitsecret.ResourceCloudInitSecret(),
 		},
+		ConfigureContextFunc: providerConfig,
 	}
-	p.ConfigureContextFunc = configure(p)
 	return p
 }
 
-func configure(p *schema.Provider) schema.ConfigureContextFunc {
-	return func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
-		kubeContext := d.Get(constants.FieldProviderKubeContext).(string)
-		kubeConfig, err := homedir.Expand(d.Get(constants.FieldProviderKubeConfig).(string))
-		if err != nil {
-			return nil, diag.FromErr(err)
-		}
-
-		c, err := client.NewClient(kubeConfig, kubeContext)
-		if err != nil {
-			return nil, diag.FromErr(err)
-		}
-
-		// check harvester version from settings
-		serverVersion, err := c.HarvesterClient.HarvesterhciV1beta1().Settings().Get(context.Background(), "server-version", metav1.GetOptions{})
-		if err != nil {
-			return nil, diag.FromErr(err)
-		}
-		// harvester version v1.0-head, v1.0.2, v1.0.3 is not supported
-		if strings.HasPrefix(serverVersion.Value, "v1.0") {
-			return nil, diag.FromErr(fmt.Errorf("current Harvester server version is %s, the minimum supported version is v1.1.0", serverVersion.Value))
-		}
-
-		return c, nil
+func providerConfig(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+	kubeContext := d.Get(constants.FieldProviderKubeContext).(string)
+	kubeConfig, err := homedir.Expand(d.Get(constants.FieldProviderKubeConfig).(string))
+	if err != nil {
+		return nil, diag.FromErr(err)
 	}
+
+	c, err := client.NewClient(kubeConfig, kubeContext)
+	if err != nil {
+		return nil, diag.FromErr(err)
+	}
+
+	// check harvester version from settings
+	serverVersion, err := c.HarvesterClient.
+		HarvesterhciV1beta1().
+		Settings().
+		Get(ctx, "server-version", metav1.GetOptions{})
+	if err != nil {
+		return nil, diag.FromErr(err)
+	}
+	// harvester version v1.0-head, v1.0.2, v1.0.3 is not supported
+	if strings.HasPrefix(serverVersion.Value, "v1.0") {
+		return nil, diag.FromErr(fmt.Errorf("current Harvester server version is %s, the minimum supported version is v1.1.0", serverVersion.Value))
+	}
+
+	return c, nil
 }

--- a/internal/provider/storageclass/resource_storageclass.go
+++ b/internal/provider/storageclass/resource_storageclass.go
@@ -2,6 +2,7 @@ package storageclass
 
 import (
 	"context"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -26,6 +27,13 @@ func ResourceStorageClass() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: Schema(),
+		Timeouts: &schema.ResourceTimeout{
+			Create:  schema.DefaultTimeout(2 * time.Minute),
+			Read:    schema.DefaultTimeout(2 * time.Minute),
+			Update:  schema.DefaultTimeout(2 * time.Minute),
+			Delete:  schema.DefaultTimeout(2 * time.Minute),
+			Default: schema.DefaultTimeout(2 * time.Minute),
+		},
 	}
 }
 

--- a/internal/util/state.go
+++ b/internal/util/state.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,10 +32,10 @@ func HasDeleted(events watch.Interface) bool {
 	return deleted
 }
 
-func WatchOptions(name string, timeoutSeconds int64) metav1.ListOptions {
+func WatchOptions(name string, timeout time.Duration) metav1.ListOptions {
 	return metav1.ListOptions{
 		FieldSelector:  fmt.Sprintf("metadata.name=%s", name),
 		Watch:          true,
-		TimeoutSeconds: &timeoutSeconds,
+		TimeoutSeconds: func() *int64 { to := timeout.Milliseconds() / 1000; return &to }(),
 	}
 }

--- a/pkg/constants/constants_image.go
+++ b/pkg/constants/constants_image.go
@@ -18,4 +18,5 @@ const (
 	StateImageDownloading  = "Downloading"
 	StateImageExporting    = "Exporting"
 	StateImageInitializing = "Initializing"
+	StateImageTerminating  = "Terminating"
 )


### PR DESCRIPTION
By convention (https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) terraform resources can have timeouts associated with their operations through `timeout` blocks.
This change sets the default timeout to 2 minutes, except where other defaults were hard-coded before and allows users to specify timeout blocks without causing parsing errors.

Use the contexts to setup and propagate deadlines for each operation according to what is set in the terraform file. Since each API call happens within the same context, the same deadline applies, giving each operation (create, update, read, delete) as a whole the configured timeout rather than setting this timeout on individual API calls of the operation.

Where applicable, the timeout of resources is measured against the observed changes of the API resources or events rather than completion of API calls. This is particularly important for resources where operations can take a lot longer than the API call. E.g. for the Delete operation on a Volume, the time until a matching event is observed is counted. For the Update operation of a VirtualMachine, the time (if necessary) until the VM resource has been restarted and is observed in running state is counted. For a contrast, the Delete operation on a storage class happens almost immediately and the timeout is only counted against the API call.

As an example how timeout blocks can be used, here is an example terraform script for loading a VM image into Harvester from a slow server. Normally this operation should succeed without explicitly setting a timeout, but due to the slow downloadspeed from the server onto the Harvester node, the timeout for creating or updating the resource needs to be significantly increased.

```
terraform {
  required_providers {
    harvester = {
[...]
    }
  }
}

provider "harvester" {
  kubeconfig = "/home/user/.kube.harvester/config.yaml"
}

resource "harvester_image" "opensuse154" {
  name      = "opensuse154"
  namespace = "harvester-public"

  display_name = "openSUSE-Leap-15.4.x86_64-NoCloud.qcow2"
  source_type  = "download"
  url          = "https://mirrors.superslow.org/images/openSUSE-Leap-15.4.x86_64-NoCloud.qcow2"

  timeouts {
    create = "20m"
    update = "20m"
  }
}
```

fixes: https://github.com/harvester/harvester/issues/5632
related issues:
- https://github.com/harvester/harvester/issues/5632
- https://github.com/harvester/harvester/issues/5786