### PR TITLE
Fix: panic and crash when `size` parameter of a `disk` is not parseable into a `Quantity`

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -20,6 +20,7 @@ RUN wget --quiet https://github.com/docker/buildx/releases/download/v0.13.1/buil
     mv buildx-v0.13.1.linux-${ARCH} /usr/local/bin/buildx && \
     mv terraform /usr/local/bin/terraform
 
+ENV DAPPER_RUN_ARGS="--network host -v /run/containerd/containerd.sock:/run/containerd/containerd.sock"
 ENV DAPPER_ENV REPO TAG DRONE_TAG
 ENV DAPPER_SOURCE /go/src/github.com/harvester/terraform-provider-harvester
 ENV DAPPER_OUTPUT ./bin ./dist


### PR DESCRIPTION
### Description

The `harvester_virtualmachine` and its subresources are parsed and converted into a `kubevirtv1.VirtualMachine` object using a `VMBuilder` factory. This `VMBuilder` assumes that parameters given to it have some semblance of sanity. This means amongst other things that the `size` parameter of a volume must be a parseable into a `resource.Quantity` using `resource.MustParse`, e.g. `"10Gi"`.
The `size` parameter isn't always required, but when it is required, if a user omits it the Terraform provider will just fill it with a default value.
Since the `size` parameter of a `disk` subresource of a `harvester_virtualmachine` is user input, it must be sanitized before being passed on to the `VMBuilder`. In case it isn't parseable, a sensible error must be emitted and further processing of the virtual machine resource must be stopped.
To do this, the parsing function of the `disk` subresource of `harvester_virtualmachine` resources is re-ordered such that the different cases where the `size` parameter matters and where it is ignored are more clearly defined.
When it matters, the `size` parameter is checked before being passed on to the `VMBuilder`.
This also allows a default value to be used when the `size` parameter isn't given, but is required.

### Related Issues:

- https://github.com/harvester/harvester/issues/7139