### PR TITLE
Terraform Provider: Kubeconfig as Base64 string

### DIFF
--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -9,4 +9,10 @@ terraform {
 }
 
 provider "harvester" {
+  # Path to kubeconfig file
+  kubeconfig = "/path/to/kubeconfig.yaml"
+  # alternatively the base64 encoded contents of the kubeconfig file:
+  # kubeconfig = "YXBpVmVyc2lvb...xvY2FsIgo="
+
+  kubecontext = "mycontext"
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -11,7 +11,12 @@ terraform {
 provider "harvester" {
   # Path to kubeconfig file
   kubeconfig = "/path/to/kubeconfig.yaml"
-  # alternatively the base64 encoded contents of the kubeconfig file:
+
+  # Alternatively the base64 encoded contents of the kubeconfig file.
+  # CAUTION: When supplying the kubeconfig as base64 encoded string, the
+  # content will be preserved in the Terraform state files in the clear.
+  # Take appropriate measures to avoid leaking sensitive information.
+  #
   # kubeconfig = "YXBpVmVyc2lvb...xvY2FsIgo="
 
   kubecontext = "mycontext"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mitchellh/go-homedir"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/harvester/terraform-provider-harvester/internal/provider/cloudinitsecret"
@@ -68,10 +67,7 @@ func Provider() *schema.Provider {
 
 func providerConfig(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	kubeContext := d.Get(constants.FieldProviderKubeContext).(string)
-	kubeConfig, err := homedir.Expand(d.Get(constants.FieldProviderKubeConfig).(string))
-	if err != nil {
-		return nil, diag.FromErr(err)
-	}
+	kubeConfig := d.Get(constants.FieldProviderKubeConfig).(string)
 
 	c, err := client.NewClient(kubeConfig, kubeContext)
 	if err != nil {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -30,7 +30,7 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "",
-				Description: "kubeconfig file path, users can use the KUBECONFIG environment variable instead",
+				Description: "kubeconfig file path or content of the kubeconfig file as base64 encoded string, users can use the KUBECONFIG environment variable instead.",
 			},
 			constants.FieldProviderKubeContext: {
 				Type:        schema.TypeString,

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -3,6 +3,8 @@ package client
 import (
 	"encoding/base64"
 
+	"github.com/mitchellh/go-homedir"
+
 	harvnetworkclient "github.com/harvester/harvester-network-controller/pkg/generated/clientset/versioned"
 	harvclient "github.com/harvester/harvester/pkg/generated/clientset/versioned"
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/scheme"
@@ -70,7 +72,12 @@ func NewClient(kubeConfig, kubeContext string) (*Client, error) {
 }
 
 func restConfigFromFile(kubeConfig, kubeContext string) (*rest.Config, error) {
-	clientConfig := kubeconfig.GetNonInteractiveClientConfigWithContext(kubeConfig, kubeContext)
+	clientConfigPath, err := homedir.Expand(kubeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	clientConfig := kubeconfig.GetNonInteractiveClientConfigWithContext(clientConfigPath, kubeContext)
 	return clientConfig.ClientConfig()
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"encoding/base64"
+
 	harvnetworkclient "github.com/harvester/harvester-network-controller/pkg/generated/clientset/versioned"
 	harvclient "github.com/harvester/harvester/pkg/generated/clientset/versioned"
 	"github.com/harvester/harvester/pkg/generated/clientset/versioned/scheme"
@@ -9,6 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	storageclient "k8s.io/client-go/kubernetes/typed/storage/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 type Client struct {
@@ -21,11 +24,17 @@ type Client struct {
 }
 
 func NewClient(kubeConfig, kubeContext string) (*Client, error) {
-	clientConfig := kubeconfig.GetNonInteractiveClientConfigWithContext(kubeConfig, kubeContext)
-	restConfig, err := clientConfig.ClientConfig()
-	if err != nil {
-		return nil, err
+	var (
+		restConfig *rest.Config
+		err        error
+	)
+
+	if restConfig, err = restConfigFromBase64(kubeConfig); err != nil {
+		if restConfig, err = restConfigFromFile(kubeConfig, kubeContext); err != nil {
+			return nil, err
+		}
 	}
+
 	copyConfig := rest.CopyConfig(restConfig)
 	copyConfig.GroupVersion = &kubeschema.GroupVersion{Group: "subresources.kubevirt.io", Version: "v1"}
 	copyConfig.APIPath = "/apis"
@@ -58,4 +67,17 @@ func NewClient(kubeConfig, kubeContext string) (*Client, error) {
 		HarvesterClient:           harvClient,
 		HarvesterNetworkClient:    harvNetworkClient,
 	}, nil
+}
+
+func restConfigFromFile(kubeConfig, kubeContext string) (*rest.Config, error) {
+	clientConfig := kubeconfig.GetNonInteractiveClientConfigWithContext(kubeConfig, kubeContext)
+	return clientConfig.ClientConfig()
+}
+
+func restConfigFromBase64(kubeConfigBase64 string) (*rest.Config, error) {
+	bytes, err := base64.StdEncoding.DecodeString(kubeConfigBase64)
+	if err != nil {
+		return nil, err
+	}
+	return clientcmd.RESTConfigFromKubeConfig(bytes)
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -4,8 +4,9 @@ const (
 	NamespaceDefault         = "default"
 	NamespaceHarvesterSystem = "harvester-system"
 
-	FieldProviderKubeConfig  = "kubeconfig"
-	FieldProviderKubeContext = "kubecontext"
+	FieldProviderKubeConfig       = "kubeconfig"
+	FieldProviderKubeContext      = "kubecontext"
+	FieldProviderKubeConfigBase64 = "kubeconfig_base64"
 
 	FieldCommonName        = "name"
 	FieldCommonNamespace   = "namespace"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -4,9 +4,8 @@ const (
 	NamespaceDefault         = "default"
 	NamespaceHarvesterSystem = "harvester-system"
 
-	FieldProviderKubeConfig       = "kubeconfig"
-	FieldProviderKubeContext      = "kubecontext"
-	FieldProviderKubeConfigBase64 = "kubeconfig_base64"
+	FieldProviderKubeConfig  = "kubeconfig"
+	FieldProviderKubeContext = "kubecontext"
 
 	FieldCommonName        = "name"
 	FieldCommonNamespace   = "namespace"


### PR DESCRIPTION
Accept kubeconfig as base64 string.
When configuring the Harvester Terraform provider, the kubeconfig can either be given as path to a file, from which to read, or the contents can be supplied directly as base64 string.
This allows for greater flexibility in supplying this sensitive data to the Terraform provider.

related-to: harvester/harvester#6234