### PR TITLE
fix(virtualmachine): ssh-user and ssh_keys

### DIFF
--- a/docs/data-sources/virtualmachine.md
+++ b/docs/data-sources/virtualmachine.md
@@ -39,12 +39,14 @@ data "harvester_virtualmachine" "opensuse154" {
 
 - `cloudinit` (List of Object) (see [below for nested schema](#nestedatt--cloudinit))
 - `cpu` (Number)
+- `cpu_pinning` (Boolean) To enable VM CPU pinning, ensure that at least one node has the CPU manager enabled
 - `description` (String) Any text you want that better describes this resource
 - `disk` (List of Object) (see [below for nested schema](#nestedatt--disk))
 - `efi` (Boolean)
 - `hostname` (String)
 - `id` (String) The ID of this resource.
 - `input` (List of Object) (see [below for nested schema](#nestedatt--input))
+- `isolate_emulator_thread` (Boolean) To enable isolate emulator thread, ensure that at least one node has the CPU manager enabled, also VM CPU pinning must be enabled. Note that enable option will allocate an additional dedicated CPU.
 - `machine_type` (String)
 - `memory` (String)
 - `message` (String)
@@ -54,10 +56,14 @@ data "harvester_virtualmachine" "opensuse154" {
 - `restart_after_update` (Boolean) restart vm after the vm is updated
 - `run_strategy` (String) more info: https://kubevirt.io/user-guide/virtual_machines/run_strategies/
 - `secure_boot` (Boolean) EFI must be enabled to use this feature
-- `ssh_keys` (List of String)
+- `ssh_keys` (List of String) The `ssh_keys` are added to `cloudinit.user_data` if:
+1. Both `cloudinit.user_data_base64` and `cloudinit.user_data_secret_name` are empty.
+2. There is no `ssh_authorized_keys` field in `cloudinit.user_data`.
 - `start` (Boolean, Deprecated)
 - `state` (String)
-- `tags` (Map of String)
+- `tags` (Map of String) The `ssh-user` is added to `cloudinit.user_data` if:
+1. Both `cloudinit.user_data_base64` and `cloudinit.user_data_secret_name` are empty.
+2. There is no `user` field in `cloudinit.user_data`.
 - `tpm` (List of Object) (see [below for nested schema](#nestedatt--tpm))
 
 <a id="nestedatt--cloudinit"></a>

--- a/docs/data-sources/virtualmachine.md
+++ b/docs/data-sources/virtualmachine.md
@@ -61,7 +61,9 @@ data "harvester_virtualmachine" "opensuse154" {
 2. There is no `ssh_authorized_keys` field in `cloudinit.user_data`.
 - `start` (Boolean, Deprecated)
 - `state` (String)
-- `tags` (Map of String) The `ssh-user` is added to `cloudinit.user_data` if:
+- `tags` (Map of String) The tag is reflected as label on the VM.
+For example: `sample-tag = sample` adds label `tag.harvesterhci.io/sample-tag: sample`.
+For `ssh-user` tag, the value is added to `cloudinit.user_data` if:
 1. Both `cloudinit.user_data_base64` and `cloudinit.user_data_secret_name` are empty.
 2. There is no `user` field in `cloudinit.user_data`.
 - `tpm` (List of Object) (see [below for nested schema](#nestedatt--tpm))

--- a/docs/resources/virtualmachine.md
+++ b/docs/resources/virtualmachine.md
@@ -214,7 +214,9 @@ resource "harvester_virtualmachine" "opensuse154" {
 1. Both `cloudinit.user_data_base64` and `cloudinit.user_data_secret_name` are empty.
 2. There is no `ssh_authorized_keys` field in `cloudinit.user_data`.
 - `start` (Boolean, Deprecated)
-- `tags` (Map of String) The `ssh-user` is added to `cloudinit.user_data` if:
+- `tags` (Map of String) The tag is reflected as label on the VM.
+For example: `sample-tag = sample` adds label `tag.harvesterhci.io/sample-tag: sample`.
+For `ssh-user` tag, the value is added to `cloudinit.user_data` if:
 1. Both `cloudinit.user_data_base64` and `cloudinit.user_data_secret_name` are empty.
 2. There is no `user` field in `cloudinit.user_data`.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/docs/resources/virtualmachine.md
+++ b/docs/resources/virtualmachine.md
@@ -197,10 +197,12 @@ resource "harvester_virtualmachine" "opensuse154" {
 
 - `cloudinit` (Block List, Max: 1) (see [below for nested schema](#nestedblock--cloudinit))
 - `cpu` (Number)
+- `cpu_pinning` (Boolean) To enable VM CPU pinning, ensure that at least one node has the CPU manager enabled
 - `description` (String) Any text you want that better describes this resource
 - `efi` (Boolean)
 - `hostname` (String)
 - `input` (Block List) (see [below for nested schema](#nestedblock--input))
+- `isolate_emulator_thread` (Boolean) To enable isolate emulator thread, ensure that at least one node has the CPU manager enabled, also VM CPU pinning must be enabled. Note that enable option will allocate an additional dedicated CPU.
 - `machine_type` (String)
 - `memory` (String)
 - `namespace` (String)
@@ -208,9 +210,13 @@ resource "harvester_virtualmachine" "opensuse154" {
 - `restart_after_update` (Boolean) restart vm after the vm is updated
 - `run_strategy` (String) more info: https://kubevirt.io/user-guide/virtual_machines/run_strategies/
 - `secure_boot` (Boolean) EFI must be enabled to use this feature
-- `ssh_keys` (List of String)
+- `ssh_keys` (List of String) The `ssh_keys` are added to `cloudinit.user_data` if:
+1. Both `cloudinit.user_data_base64` and `cloudinit.user_data_secret_name` are empty.
+2. There is no `ssh_authorized_keys` field in `cloudinit.user_data`.
 - `start` (Boolean, Deprecated)
-- `tags` (Map of String)
+- `tags` (Map of String) The `ssh-user` is added to `cloudinit.user_data` if:
+1. Both `cloudinit.user_data_base64` and `cloudinit.user_data_secret_name` are empty.
+2. There is no `user` field in `cloudinit.user_data`.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `tpm` (Block List, Max: 1) (see [below for nested schema](#nestedblock--tpm))
 

--- a/internal/provider/keypair/resource_keypair.go
+++ b/internal/provider/keypair/resource_keypair.go
@@ -50,6 +50,7 @@ func resourceKeypairCreate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.FromErr(err)
 	}
 
+	d.SetId(helper.BuildID(namespace, name))
 	return diag.FromErr(resourceKeyPairImport(d, obj))
 }
 

--- a/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
+++ b/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
@@ -335,7 +335,7 @@ func (c *Constructor) Setup() util.Processors {
 						if cloudInitSource.UserData == "" {
 							cloudInitSource.UserData = fmt.Sprintf("#cloud-config\nssh_authorized_keys:\n  - %s", strings.Join(publicKeys, "\n  - "))
 						} else {
-							cloudInitSource.UserData += fmt.Sprintf("ssh_authorized_keys:\n  - %s", strings.Join(publicKeys, "\n  - "))
+							cloudInitSource.UserData += fmt.Sprintf("\nssh_authorized_keys:\n  - %s", strings.Join(publicKeys, "\n  - "))
 						}
 					}
 				}

--- a/internal/provider/virtualmachine/schema_virtualmachine.go
+++ b/internal/provider/virtualmachine/schema_virtualmachine.go
@@ -144,7 +144,9 @@ please use %s instead of this deprecated field:
 		},
 	}
 	util.NamespacedSchemaWrap(s, false)
-	s[constants.FieldCommonTags].Description = "The `ssh-user` is added to `cloudinit.user_data` if:\n" +
+	s[constants.FieldCommonTags].Description = "The tag is reflected as label on the VM.\n" +
+		"For example: `sample-tag = sample` adds label `tag.harvesterhci.io/sample-tag: sample`.\n" +
+		"For `ssh-user` tag, the value is added to `cloudinit.user_data` if:\n" +
 		"1. Both `cloudinit.user_data_base64` and `cloudinit.user_data_secret_name` are empty.\n" +
 		"2. There is no `user` field in `cloudinit.user_data`.\n"
 	return s

--- a/internal/provider/virtualmachine/schema_virtualmachine.go
+++ b/internal/provider/virtualmachine/schema_virtualmachine.go
@@ -72,6 +72,9 @@ please use %s instead of this deprecated field:
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},
+			Description: "The `ssh_keys` are added to `cloudinit.user_data` if:\n" +
+				"1. Both `cloudinit.user_data_base64` and `cloudinit.user_data_secret_name` are empty.\n" +
+				"2. There is no `ssh_authorized_keys` field in `cloudinit.user_data`.",
 		},
 		constants.FieldVirtualMachineCloudInit: {
 			Type:     schema.TypeList,
@@ -141,6 +144,9 @@ please use %s instead of this deprecated field:
 		},
 	}
 	util.NamespacedSchemaWrap(s, false)
+	s[constants.FieldCommonTags].Description = "The `ssh-user` is added to `cloudinit.user_data` if:\n" +
+		"1. Both `cloudinit.user_data_base64` and `cloudinit.user_data_secret_name` are empty.\n" +
+		"2. There is no `user` field in `cloudinit.user_data`.\n"
 	return s
 }
 

--- a/pkg/constants/constants_virtualmachine.go
+++ b/pkg/constants/constants_virtualmachine.go
@@ -79,3 +79,7 @@ const (
 const (
 	FieldTPMName = "name"
 )
+
+const (
+	LabelSSHUsername = "ssh-user"
+)


### PR DESCRIPTION
https://github.com/harvester/harvester/issues/7790

## Test cases

Sample terraform:
```
data "harvester_image" "ubuntu20" {
  name      = "focal-image"
  namespace = "default"
}

resource "harvester_virtualmachine" "ubuntu20" {
  name                 = "ubuntu20"
  namespace            = "default"
  restart_after_update = true

  description = "test ubuntu20 raw image"
  tags = {
    ssh-user = "thisistest"
  }

  cpu    = 1
  memory = "2Gi"

  run_strategy    = "RerunOnFailure"
  hostname        = "ubuntu20"
  reserved_memory = "100Mi"
  machine_type    = "q35"

  network_interface {
    name           = "nic-1"
    wait_for_lease = true
  }

  disk {
    name       = "rootdisk"
    type       = "disk"
    size       = "10Gi"
    bus        = "virtio"
    boot_order = 1

    image       = data.harvester_image.ubuntu20.id
    auto_delete = true
  }

  cloudinit {
    user_data    = <<-EOF
      #cloud-config
      password: test
      chpasswd:
        expire: false
      ssh_pwauth: true
      package_update: true
      packages:
        - qemu-guest-agent
      runcmd:
        - - systemctl
          - enable
          - '--now'
          - qemu-guest-agent
      EOF
  }

  input {
    name = "tablet"
    type = "tablet"
    bus  = "usb"
  }
}
```

### Case 1: Set `ssh-user`. No `user` field in `user_data`. Don't set `user_data_base64` and `user_data_secret_name`.

User can use `ssh-user` to login VM.

### Case 2: Set `ssh-user`. Set `user` field in one of `user_data`, `user_data_base64`, or `user_data_secret_name`.

Example:
```
  cloudinit {
    user_data    = <<-EOF
      #cloud-config
      user: thisistest
      password: test
      chpasswd:
        expire: false
      ssh_pwauth: true
      package_update: true
      packages:
        - qemu-guest-agent
      runcmd:
        - - systemctl
          - enable
          - '--now'
          - qemu-guest-agent
      EOF
  }

```

The `ssh-user` doesn't take effect. User can use `user` field to login VM.

### Case 3: Set `ssh_keys`. No `ssh_authorized_keys` field in `user_data`, `user_data_base64`, and `user_data_secret_name`.

User can use `ssh_keys` to login VM.

### Case 4: Set `ssh_keys`. Set `ssh_authorized_keys` field in one of `user_data`, `user_data_base64`, or `user_data_secret_name`. The `ssh_authorized_keys` doesn't contain all `ssh_keys`.

Example:

```
resource "harvester_ssh_key" "mysshkey1" {
  name      = "mysshkey1"
  namespace = "default"

  public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJKp3OSPmU5IHSdmvgVOEmwHDICgnlRLDyHUEu9XrSmN your_email1@example.com"
}

resource "harvester_ssh_key" "mysshkey2" {
  name      = "mysshkey2"
  namespace = "default"

  public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHR8gzUIQViRbQoNlpR6smuPSlHQAG14ViB/Aksde/ch your_email2@example.com"
}

resource "harvester_virtualmachine" "ubuntu20" {
...
  ssh_keys = [
    harvester_ssh_key.mysshkey1.id,
    harvester_ssh_key.mysshkey2.id
  ]

  cloudinit {
    /* user_data_secret_name    = harvester_cloudinit_secret.cloud-config-ubuntu20.name */
    /* network_data_secret_name = harvester_cloudinit_secret.cloud-config-ubuntu20.name */
    user_data    = <<-EOF
      #cloud-config
      user: ubuntu
      password: test
      chpasswd:
        expire: false
      ssh_pwauth: true
      package_update: true
      packages:
        - qemu-guest-agent
      runcmd:
        - - systemctl
          - enable
          - '--now'
          - qemu-guest-agent
      ssh_authorized_keys:
      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJKp3OSPmU5IHSdmvgVOEmwHDICgnlRLDyHUEu9XrSmN your_email1@example.com
      EOF
  }
}
```

Terraform doesn't work and get error message like:
```
╷
│ Error: missing ssh public keys in cloud-int userdata ssh_authorized_keys section, ssh_keys: [default/mysshkey2].
│ Either remove unused ssh keys from "ssh_keys" or add ssh public keys to cloud-int userdata ssh_authorized_keys section.
│
│   with harvester_virtualmachine.ubuntu20,
│   on main.tf line 51, in resource "harvester_virtualmachine" "ubuntu20":
│   51: resource "harvester_virtualmachine" "ubuntu20" {
│
╵
```
