### PR TITLE
Add node_selector capability to harvester_virtualmachine

### DIFF
--- a/docs/resources/virtualmachine.md
+++ b/docs/resources/virtualmachine.md
@@ -82,6 +82,11 @@ resource "harvester_virtualmachine" "ubuntu20" {
   reserved_memory = "100Mi"
   machine_type    = "q35"
 
+  node_selector = {
+    "kubernetes.io/arch" = "amd64"
+    "node-role"          = "worker"
+  }
+
   network_interface {
     name           = "nic-1"
     wait_for_lease = true
@@ -206,6 +211,7 @@ resource "harvester_virtualmachine" "opensuse154" {
 - `machine_type` (String)
 - `memory` (String)
 - `namespace` (String)
+- `node_selector` (Map of String) Node selector to specify on which nodes the VM should be scheduled
 - `reserved_memory` (String)
 - `restart_after_update` (Boolean) restart vm after the vm is updated
 - `run_strategy` (String) more info: https://kubevirt.io/user-guide/virtual_machines/run_strategies/

--- a/examples/resources/harvester_virtualmachine/resource.tf
+++ b/examples/resources/harvester_virtualmachine/resource.tf
@@ -67,6 +67,11 @@ resource "harvester_virtualmachine" "ubuntu20" {
   reserved_memory = "100Mi"
   machine_type    = "q35"
 
+  node_selector = {
+    "kubernetes.io/arch" = "amd64"
+    "node-role"          = "worker"
+  }
+
   network_interface {
     name           = "nic-1"
     wait_for_lease = true

--- a/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
+++ b/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
@@ -382,6 +382,23 @@ func (c *Constructor) Setup() util.Processors {
 				return nil
 			},
 		},
+		{
+			Field: constants.FieldVirtualMachineNodeSelector,
+			Parser: func(i interface{}) error {
+				nodeSelector := i.(map[string]interface{})
+				if len(nodeSelector) > 0 {
+					nodeSelectorMap := make(map[string]string)
+					for k, v := range nodeSelector {
+						nodeSelectorMap[k] = v.(string)
+					}
+					if vmBuilder.VirtualMachine.Spec.Template.Spec.NodeSelector == nil {
+						vmBuilder.VirtualMachine.Spec.Template.Spec.NodeSelector = make(map[string]string)
+					}
+					vmBuilder.VirtualMachine.Spec.Template.Spec.NodeSelector = nodeSelectorMap
+				}
+				return nil
+			},
+		},
 	}
 	return append(processors, customProcessors...)
 }

--- a/internal/provider/virtualmachine/schema_virtualmachine.go
+++ b/internal/provider/virtualmachine/schema_virtualmachine.go
@@ -142,6 +142,14 @@ please use %s instead of this deprecated field:
 			Optional:    true,
 			Default:     false,
 		},
+		constants.FieldVirtualMachineNodeSelector: {
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Description: "Node selector to specify on which nodes the VM should be scheduled",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
 	}
 	util.NamespacedSchemaWrap(s, false)
 	s[constants.FieldCommonTags].Description = "The tag is reflected as label on the VM.\n" +

--- a/pkg/constants/constants_virtualmachine.go
+++ b/pkg/constants/constants_virtualmachine.go
@@ -22,6 +22,7 @@ const (
 	FieldVirtualMachineSecureBoot            = "secure_boot"
 	FieldVirtualMachineCPUPinning            = "cpu_pinning"
 	FieldVirtualMachineIsolateEmulatorThread = "isolate_emulator_thread"
+	FieldVirtualMachineNodeSelector          = "node_selector"
 
 	StateVirtualMachineStarting = "Starting"
 	StateVirtualMachineRunning  = "Running"


### PR DESCRIPTION
This PR aims at adding the possibility to select the node on which the VM can run using labels, this feature is important for zone handling and other node affinity concepts