### PR TITLE
fixups for loadbalancer resource constructor

### DIFF
--- a/examples/resources/harvester_ippool/resources.tf
+++ b/examples/resources/harvester_ippool/resources.tf
@@ -2,25 +2,25 @@ resource "harvester_ippool" "service_ips" {
   name = "service-ips"
 
   range {
-    start   = "10.11.0.1"
-    end     = "10.11.0.254"
-    subnet  = "10.11.0.1/24"
-    gateway = "10.11.0.1"
+    start   = "192.168.1.10"
+    end     = "192.168.1.80"
+    subnet  = "192.168.1.1/24"
+    gateway = "192.168.1.1"
   }
 
   range {
-    start   = "10.12.0.1"
-    end     = "10.12.0.254"
-    subnet  = "10.12.0.1/24"
-    gateway = "10.12.0.1"
+    start   = "192.168.2.10"
+    end     = "192.168.2.80"
+    subnet  = "192.168.2.1/24"
+    gateway = "192.168.2.1"
   }
 
   selector {
     priority = 100
-    network  = "vm-network"
+    network  = "default/vm-network"
     scope {
       project       = "services"
-      namespace     = "prod-default"
+      namespace     = "default"
       guest_cluster = "prod-services"
     }
   }

--- a/examples/resources/harvester_loadbalancer/resources.tf
+++ b/examples/resources/harvester_loadbalancer/resources.tf
@@ -26,7 +26,7 @@ resource "harvester_loadbalancer" "service_loadbalancer" {
   }
 
   # Can be "pool" or "dhcp"
-  ipam   = "pool"
+  ipam = "pool"
 
   # Only applicable if ipam="pool"
   ippool = "service-ips"
@@ -42,7 +42,7 @@ resource "harvester_loadbalancer" "service_loadbalancer" {
 
   healthcheck {
     # Must be the same as one of the listener backend ports
-    port              = 8080
+    port = 8080
 
     success_threshold = 1
     failure_threshold = 3

--- a/examples/resources/harvester_loadbalancer/resources.tf
+++ b/examples/resources/harvester_loadbalancer/resources.tf
@@ -11,34 +11,39 @@ resource "harvester_loadbalancer" "service_loadbalancer" {
   ]
 
   listener {
+    # Each listener must have a unique name
+    name         = "https"
     port         = 443
     protocol     = "tcp"
-    backend_port = 8080
+    backend_port = 8443
   }
 
   listener {
+    name         = "http"
     port         = 80
     protocol     = "tcp"
     backend_port = 8080
   }
 
-  ipam   = "ippool"
+  # Can be "pool" or "dhcp"
+  ipam   = "pool"
+
+  # Only applicable if ipam="pool"
   ippool = "service-ips"
 
+  # Can be "vm" or "cluster"
   workload_type = "vm"
 
+  # This must be a label on the VirtualMachineInstance
   backend_selector {
-    key    = "app"
-    values = ["test"]
-  }
-
-  backend_selector {
-    key    = "component"
-    values = ["frontend", "ui"]
+    key    = "harvesterhci.io/vmName"
+    values = ["testVM"]
   }
 
   healthcheck {
-    port              = 443
+    # Must be the same as one of the listener backend ports
+    port              = 8080
+
     success_threshold = 1
     failure_threshold = 3
     period_seconds    = 10

--- a/internal/provider/loadbalancer/resource_loadbalancer_constructor.go
+++ b/internal/provider/loadbalancer/resource_loadbalancer_constructor.go
@@ -40,6 +40,11 @@ func (c *Constructor) Setup() util.Processors {
 			Required: false,
 		},
 		{
+			Field:    constants.FieldLoadBalancerIPPool,
+			Parser:   c.subresourceLoadBalancerIPPoolParser,
+			Required: false,
+		},
+		{
 			Field:    constants.SubresourceTypeLoadBalancerListener,
 			Parser:   c.subresourceLoadBalancerListenerParser,
 			Required: true,
@@ -90,7 +95,7 @@ func Updater(loadbalancer *loadbalancerv1.LoadBalancer) util.Constructor {
 func (c *Constructor) subresourceLoadBalancerWorkloadTypeParser(data interface{}) error {
 	workloadType := data.(string)
 
-	if workloadType != "vm" && workloadType != "cluster" {
+	if workloadType != constants.LoadBalancerWorkloadTypeVM && workloadType != constants.LoadBalancerWorkloadTypeCluster {
 		return fmt.Errorf("invalid value for workload type: %v", workloadType)
 	}
 
@@ -102,11 +107,18 @@ func (c *Constructor) subresourceLoadBalancerWorkloadTypeParser(data interface{}
 func (c *Constructor) subresourceLoadBalancerIPAMParser(data interface{}) error {
 	ipam := data.(string)
 
-	if ipam != "dhcp" && ipam != "cluster" {
+	if ipam != constants.LoadBalancerIPAMPool && ipam != constants.LoadBalancerIPAMDHCP {
 		return fmt.Errorf("invalid value for IPAM: %v", ipam)
 	}
 
 	c.LoadBalancer.Spec.IPAM = loadbalancerv1.IPAM(ipam)
+	return nil
+}
+
+func (c *Constructor) subresourceLoadBalancerIPPoolParser(data interface{}) error {
+	pool := data.(string)
+
+	c.LoadBalancer.Spec.IPPool = pool
 	return nil
 }
 


### PR DESCRIPTION

#### Problem:

- Missing Parser for the `ippool` field of the load balancer resource
- Use of incorrect in-place constants for validating the IPAM and workload type fields
- Inaccurate examples

#### Solution:

- Implement field parser for ippool field
- Use correct constants for field validation of IPAM and workload type field
- Update examples with working code and add clarifying annotations

#### Related Issue(s):

related-to: harvester/harvester#4814

#### Test plan:

The following terraform file should now create correct resources.
Modification to the IP ranges to fit the test environment may be necessary.

```
resource "harvester_image" "ubuntu20" {
  name      = "ubuntu20"
  namespace = "harvester-public"

  display_name = "ubuntu-20.04-server-cloudimg-amd64.img"
  source_type  = "download"
  url          = "http://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.img"
}

resource "harvester_virtualmachine" "ubuntu20" {
  name                 = "ubuntu20"
  namespace            = "default"
  restart_after_update = true

  description = "test ubuntu20 raw image"
  tags = {
    ssh-user = "ubuntu"
    app = "test"
    component = "frontend"
  }

  cpu    = 2
  memory = "2Gi"

  run_strategy    = "RerunOnFailure"
  hostname        = "ubuntu20"
  reserved_memory = "100Mi"
  machine_type    = "q35"

  network_interface {
    name           = "nic-1"
    wait_for_lease = true
  }

  disk {
    name       = "rootdisk"
    type       = "disk"
    size       = "10Gi"
    bus        = "virtio"
    boot_order = 1

    image       = harvester_image.ubuntu20.id
    auto_delete = true
  }

  disk {
    name        = "emptydisk"
    type        = "disk"
    size        = "20Gi"
    bus         = "virtio"
    auto_delete = true
  }

  cloudinit {
    user_data = <<EOT
#cloud-config
user: ubuntu
password: foobar
chpasswd:
  expire: false
packages:
  - qemu-guest-agent
  - nginx
runcmd:
  - - systemctl
    - enable
    - --now
    - qemu-guest-agent.service
  - - systemctl
    - enable
    - --now
    - nginx.service
EOT
  }
}

resource "harvester_ippool" "service_ips" {
  name = "service-ips"

  range {
    start   = "192.168.0.70"
    end     = "192.168.0.80"
    subnet  = "192.168.0.1/24"
    gateway = "192.168.0.1"
  }

  selector {
    priority = 100
    network  = "default/vm-network"
    scope {
      project       = "services"
      namespace     = "default"
      guest_cluster = "prod-services"
    }
  }
}

resource "harvester_loadbalancer" "service_loadbalancer_pool" {
  name = "service-loadbalancer-pool"

  depends_on = [
    harvester_virtualmachine.ubuntu20
  ]

  listener {
    name         = "http"
    port         = 80
    protocol     = "tcp"
    backend_port = 80
  }

  ipam   = "pool"
  ippool = "service-ips"

  workload_type = "vm"

  backend_selector {
    key    = "harvesterhci.io/vmName"
    values = ["ubuntu20"]
  }

  healthcheck {
    port              = 80
    success_threshold = 1
    failure_threshold = 3
    period_seconds    = 10
    timeout_seconds   = 5
  }
}

resource "harvester_loadbalancer" "service_loadbalancer_dhcp" {
  name = "service-loadbalancer-dhcp"

  depends_on = [
    harvester_virtualmachine.ubuntu20
  ]

  listener {
    name         = "http"
    port         = 80
    protocol     = "tcp"
    backend_port = 80
  }

  ipam   = "dhcp"

  workload_type = "vm"

  backend_selector {
    key    = "harvesterhci.io/vmName"
    values = ["ubuntu20"]
  }

  healthcheck {
    port              = 80
    success_threshold = 1
    failure_threshold = 3
    period_seconds    = 10
    timeout_seconds   = 5
  }
}

```

After applying and waiting for the state of resources to settle, the two loadbalancers should be healthy and each have their own IP.
The IPs of the loadbalancers should be reachable and if visited with a web browser, the default Nginx welcome page should be displayed.

#### Additional documentation or context


<img width="1896" height="979" alt="Screenshot at 2025-08-07 12-44-10" src="https://github.com/user-attachments/assets/7654b898-d4a7-4996-bca5-147b8771704b" />
<img width="1894" height="970" alt="Screenshot at 2025-08-07 12-43-41" src="https://github.com/user-attachments/assets/6abed8ef-2f46-4f8d-a704-97645345ed97" />
<img width="1898" height="971" alt="Screenshot at 2025-08-07 12-43-28" src="https://github.com/user-attachments/assets/09796a8e-e905-4160-82ca-0bd452b982ea" />
<img width="1888" height="978" alt="Screenshot at 2025-08-07 12-43-19" src="https://github.com/user-attachments/assets/cce0e892-a23a-4329-ad46-1d39eb1e0aa1" />
<img width="1903" height="977" alt="Screenshot at 2025-08-07 12-43-09" src="https://github.com/user-attachments/assets/5be02cf1-eb02-42f6-b017-0aa74fc305c4" />
<img width="1914" height="983" alt="Screenshot at 2025-08-07 12-43-00" src="https://github.com/user-attachments/assets/efed9721-e69f-40d3-bfce-f728c031c357" />
