### PR TITLE
feat: add node_selector to vm

### DIFF
--- a/docs/data-sources/virtualmachine.md
+++ b/docs/data-sources/virtualmachine.md
@@ -52,6 +52,7 @@ data "harvester_virtualmachine" "opensuse154" {
 - **message** (String)
 - **network_interface** (List of Object) (see [below for nested schema](#nestedatt--network_interface))
 - **node_name** (String)
+- **node_selector** (Map of String) Node selector for scheduling the VM. The key is the label key and the value is the label value.
 - **reserved_memory** (String)
 - **restart_after_update** (Boolean) restart vm after the vm is updated
 - **run_strategy** (String) more info: https://kubevirt.io/user-guide/virtual_machines/run_strategies/

--- a/docs/resources/virtualmachine.md
+++ b/docs/resources/virtualmachine.md
@@ -207,6 +207,7 @@ resource "harvester_virtualmachine" "opensuse154" {
 - **machine_type** (String)
 - **memory** (String)
 - **namespace** (String)
+- **node_selector** (Map of String) Node selector for scheduling the VM. The key is the label key and the value is the label value.
 - **reserved_memory** (String)
 - **restart_after_update** (Boolean) restart vm after the vm is updated
 - **run_strategy** (String) more info: https://kubevirt.io/user-guide/virtual_machines/run_strategies/

--- a/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
+++ b/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
@@ -382,6 +382,17 @@ func (c *Constructor) Setup() util.Processors {
 				return nil
 			},
 		},
+		{
+			Field: constants.FieldVirtualMachineNodeSelector,
+			Parser: func(i interface{}) error {
+				v := i.(map[string]interface{})
+				vmBuilder.VirtualMachine.Spec.Template.Spec.NodeSelector = make(map[string]string)
+				for k, val := range v {
+					vmBuilder.VirtualMachine.Spec.Template.Spec.NodeSelector[k] = val.(string)
+				}
+				return nil
+			},
+		},
 	}
 	return append(processors, customProcessors...)
 }

--- a/internal/provider/virtualmachine/schema_virtualmachine.go
+++ b/internal/provider/virtualmachine/schema_virtualmachine.go
@@ -142,6 +142,11 @@ please use %s instead of this deprecated field:
 			Optional:    true,
 			Default:     false,
 		},
+		constants.FieldVirtualMachineNodeSelector: {
+			Type:        schema.TypeMap,
+			Description: "Node selector for scheduling the VM. The key is the label key and the value is the label value.",
+			Optional:    true,
+		},
 	}
 	util.NamespacedSchemaWrap(s, false)
 	s[constants.FieldCommonTags].Description = "The tag is reflected as label on the VM.\n" +

--- a/pkg/constants/constants_virtualmachine.go
+++ b/pkg/constants/constants_virtualmachine.go
@@ -22,6 +22,7 @@ const (
 	FieldVirtualMachineSecureBoot            = "secure_boot"
 	FieldVirtualMachineCPUPinning            = "cpu_pinning"
 	FieldVirtualMachineIsolateEmulatorThread = "isolate_emulator_thread"
+	FieldVirtualMachineNodeSelector          = "node_selector"
 
 	StateVirtualMachineStarting = "Starting"
 	StateVirtualMachineRunning  = "Running"

--- a/pkg/importer/resource_virtualmachine_importer.go
+++ b/pkg/importer/resource_virtualmachine_importer.go
@@ -393,6 +393,7 @@ func ResourceVirtualMachineStateGetter(vm *kubevirtv1.VirtualMachine, vmi *kubev
 			constants.FieldVirtualMachineSecureBoot:            vmImporter.SecureBoot(),
 			constants.FieldVirtualMachineCPUPinning:            vmImporter.DedicatedCPUPlacement(),
 			constants.FieldVirtualMachineIsolateEmulatorThread: vmImporter.IsolateEmulatorThread(),
+			constants.FieldVirtualMachineNodeSelector:          vm.Spec.Template.Spec.NodeSelector,
 		},
 	}, nil
 }


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/8705

#### Test plan:
**Build terraform-provider-harvester**
```
> rm -rf ~/.terraform.d
> CGO_ENABLED=0 go build -mod=vendor -o bin/terraform-provider-harvester .
mkdir -p ~/.terraform.d/plugins/registry.terraform.io/harvester/harvester/0.0.0-dev/linux_amd64
cp bin/terraform-provider-harvester ~/.terraform.d/plugins/registry.terraform.io/harvester/harvester/0.0.0-dev/linux_amd64/terraform-provider-harvester_v0.0.0-dev
```

**Run terraform**
1. Create `versions.tf`.
```tf
 terraform {
   required_providers {
     harvester = {
       source  = "harvester/harvester"
       version = "0.0.0-dev"
     }
   }
 }
```
2. Create `main.tf`. Assumed your node name is `harvester-node-0`.
```tf
resource "harvester_image" "ubuntu20" {
  name      = "ubuntu-focal"
  namespace = "default"

  display_name = "ubuntu-focal"
  source_type  = "download"
  url          = "http://192.168.0.181:8000/focal-server-cloudimg-amd64.img"
}

resource "harvester_virtualmachine" "ubuntu20" {
  name                 = "ubuntu20"
  namespace            = "default"
  restart_after_update = true

  node_selector = {
    "kubernetes.io/hostname" = "harvester-node-1"
  }

  description = "test ubuntu20 raw image"
  cpu    = 1
  memory = "2Gi"

  run_strategy    = "RerunOnFailure"
  hostname        = "ubuntu20"
  reserved_memory = "100Mi"
  machine_type    = "q35"

  network_interface {
    name           = "default"
    wait_for_lease = true
  }

  disk {
    name       = "rootdisk"
    type       = "disk"
    size       = "10Gi"
    bus        = "virtio"
    boot_order = 1

    image       = harvester_image.ubuntu20.id
    auto_delete = true
  }

  cloudinit {
    /* user_data_secret_name    = harvester_cloudinit_secret.cloud-config-ubuntu20.name */
    /* network_data_secret_name = harvester_cloudinit_secret.cloud-config-ubuntu20.name */
    user_data    = <<-EOF
      #cloud-config
      user: ubuntu
      password: test
      chpasswd:
        expire: false
      ssh_pwauth: true
      package_update: true
      packages:
        - qemu-guest-agent
      runcmd:
        - - systemctl
          - enable
          - '--now'
          - qemu-guest-agent
      EOF
  }
}
```
3. Run `terraform init`.
4. Run `terraform apply` and check there is `ubuntu20` VM on node `harvester-node-0`.

#### Additional documentation or context
