### PR TITLE
add checksum field to image resource schema

### DIFF
--- a/docs/data-sources/image.md
+++ b/docs/data-sources/image.md
@@ -37,6 +37,7 @@ data "harvester_image" "opensuse154" {
 ### Read-Only
 
 - **backend** (String) The backend type of the image, either 'backing-image' or 'cdi'.
+- **checksum** (String) SHA-512 checksum of the image
 - **description** (String) Any text you want that better describes this resource
 - **message** (String)
 - **progress** (Number)

--- a/docs/resources/image.md
+++ b/docs/resources/image.md
@@ -138,6 +138,7 @@ resource "harvester_image" "decrypted_image" {
 ### Optional
 
 - **backend** (String) The backend type of the image, either 'backing-image' or 'cdi'.
+- **checksum** (String) SHA-512 checksum of the image
 - **description** (String) Any text you want that better describes this resource
 - **id** (String) The ID of this resource.
 - **namespace** (String)

--- a/internal/provider/image/resource_image_constructor.go
+++ b/internal/provider/image/resource_image_constructor.go
@@ -68,6 +68,14 @@ func (c *Constructor) Setup() util.Processors {
 			Required: true,
 		},
 		{
+			Field: constants.FieldImageChecksum,
+			Parser: func(i interface{}) error {
+				checksum := i.(string)
+				c.Image.Spec.Checksum = checksum
+				return nil
+			},
+		},
+		{
 			Field: constants.FieldImageStorageClassName,
 			Parser: func(i interface{}) error {
 				storageClassName := i.(string)

--- a/internal/provider/image/schema_image.go
+++ b/internal/provider/image/schema_image.go
@@ -88,6 +88,12 @@ func Schema() map[string]*schema.Schema {
 			Description:  "Security parameters for encryption/decryption operations. When specified, source_type must be 'clone'. Required keys: crypto_operation, source_image_name, source_image_namespace",
 			ValidateFunc: validateSecurityParameters,
 		},
+		constants.FieldImageChecksum: {
+			Type:        schema.TypeString,
+			Optional:    true,
+			ForceNew:    true,
+			Description: "SHA-512 checksum of the image",
+		},
 	}
 	util.NamespacedSchemaWrap(s, false)
 	return s

--- a/pkg/constants/constants_image.go
+++ b/pkg/constants/constants_image.go
@@ -18,6 +18,7 @@ const (
 	FieldImageCryptoOperation        = "crypto_operation"
 	FieldImageSourceImageName        = "source_image_name"
 	FieldImageSourceImageNamespace   = "source_image_namespace"
+	FieldImageChecksum               = "checksum"
 
 	StateImageUploading    = "Uploading"
 	StateImageDownloading  = "Downloading"

--- a/pkg/importer/resource_image_importer.go
+++ b/pkg/importer/resource_image_importer.go
@@ -18,6 +18,7 @@ func ResourceImageStateGetter(obj *harvsterv1.VirtualMachineImage) (*StateGetter
 		constants.FieldImageDisplayName:            obj.Spec.DisplayName,
 		constants.FieldImageSourceType:             obj.Spec.SourceType,
 		constants.FieldImageURL:                    obj.Spec.URL,
+		constants.FieldImageChecksum:               obj.Spec.Checksum,
 		constants.FieldImagePVCNamespace:           obj.Spec.PVCNamespace,
 		constants.FieldImagePVCName:                obj.Spec.PVCName,
 		constants.FieldImageProgress:               obj.Status.Progress,


### PR DESCRIPTION
Add checksum field to image resource schema and constructor. The checksum allows users to make sure an image from a download source is downloaded correctly and the content are as expected.

Changing the checksum field forces the image CRD to be re-created, because only this forces the image to be downloaded again and the checksum to be re-calculated and compared with the updated value.

related-to: harvester/harvester#8265

#### Problem:

Checksum field was absent

#### Solution:

Add checksum field

#### Related Issue(s):

harvester/harvester#8265

#### Test plan:

It's now possible to set the checksum of an image with type "download" when creating it with the Terraform provider:

```
resource "harvester_image" "opensuse_156" {
  name      = "opensuse-15.6"
  namespace = "harvester-public"

  display_name = "openSUSE-Leap-15.6"
  source_type  = "download"
  url          = "http://192.168.0.254/artifacts/openSUSE-Leap-15.6.x86_64-NoCloud.qcow2"
  checksum     = "6508cc3df86a92a7051aed50349763da277801efc8bd18aa27ff13c4325bb49117233039e2f19fc5ec8fb4587a7d246d2161d37ba015946d1bbdb8b4500c64c2"

  storage_class_name = "harvester-longhorn"
}
```

<img width="2396" height="964" alt="Screenshot at 2025-08-11 15-24-42" src="https://github.com/user-attachments/assets/e87e0fee-1032-42e3-98cb-e3a8bfeb7cf5" />

#### Additional documentation or context
