### PR TITLE
add route information to Terraform state

### DIFF
--- a/pkg/importer/resource_network_importer.go
+++ b/pkg/importer/resource_network_importer.go
@@ -49,6 +49,8 @@ func ResourceNetworkStateGetter(obj *nadv1.NetworkAttachmentDefinition) (*StateG
 		constants.FieldNetworkConfig:             obj.Spec.Config,
 		constants.FieldNetworkRouteMode:          layer3NetworkConf.Mode,
 		constants.FieldNetworkRouteDHCPServerIP:  layer3NetworkConf.ServerIPAddr,
+		constants.FieldNetworkRouteCIDR:          layer3NetworkConf.CIDR,
+		constants.FieldNetworkRouteGateWay:       layer3NetworkConf.Gateway,
 		constants.FieldNetworkRouteConnectivity:  layer3NetworkConf.Connectivity,
 		constants.FieldNetworkClusterNetworkName: obj.Labels[networkutils.KeyClusterNetworkLabel],
 	}


### PR DESCRIPTION
Import full route information into terraform state

related-to: harvester/harvester#8867
related-to: https://github.com/harvester/harvester/issues/8398#issuecomment-3166110194

#### Problem:

Route information in Terraform state incomplete, even after running `terraform refresh`

#### Solution:

Import full route information into Terraform state

#### Related Issue(s):

related-to: harvester/harvester#8867
related-to: https://github.com/harvester/harvester/issues/8398#issuecomment-3166110194

#### Test plan:

- Install Harvester (any recent version)
- Create Harvester network, e.g.:
```
resource "harvester_network" "foobar" {
  name = "foobar"
  namespace = "default"

  route_mode = "auto"
  cluster_network_name = "mgmt"
  vlan_id = 1
}
```

- Wait until route information is available
<img width="1704" height="841" alt="Screenshot at 2025-08-11 15-53-37" src="https://github.com/user-attachments/assets/01d3fbfb-0b5f-4b4c-8946-f4e35159e204" />

```
$ terraform refresh
harvester_network.foobar: Refreshing state... [id=default/foobar]
```

- Check Terraform state file
```
$ cat terraform.tfstate
{
  "version": 4,
  "terraform_version": "0.13.4",
  "serial": 23,
  "lineage": "597bca93-46ea-de90-76b7-e8931b1a3a26",
  "outputs": {},
  "resources": [
    {
      "mode": "managed",
      "type": "harvester_network",
      "name": "foobar",
      "provider": "provider[\"terraform.local/local/harvester\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "cluster_network_name": "mgmt",
            "config": "{\"cniVersion\":\"0.3.1\",\"name\":\"foobar\",\"type\":\"bridge\",\"bridge\":\"mgmt-br\",\"promiscMode\":true,\"vlan\":1,\"ipam\":{}}",
            "description": "",
            "id": "default/foobar",
            "message": null,
            "name": "foobar",
            "namespace": "default",
            "route_cidr": "192.168.0.0/24",
            "route_connectivity": "true",
            "route_dhcp_server_ip": "",
            "route_gateway": "192.168.0.1",
            "route_mode": "auto",
            "state": null,
            "tags": {},
            "timeouts": {
              "create": null,
              "default": null,
              "delete": null,
              "read": null,
              "update": null
            },
            "vlan_id": 1
          },
          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAsImRlZmF1bHQiOjEyMDAwMDAwMDAwMCwiZGVsZXRlIjozMDAwMDAwMDAwMDAsInJlYWQiOjEyMDAwMDAwMDAwMCwidXBkYXRlIjoxMjAwMDAwMDAwMDB9LCJzY2hlbWFfdmVyc2lvbiI6IjAifQ=="
        }
      ]
    }
  ]
}
```
Note that `route_cidr` and `route_gateway` are now correctly filled in

#### Additional documentation or context
