### PR TITLE
importer: differentiate and ignore link-local IPs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ terraform.tfstate
 terraform.tfstate.backup
 terraform-provider-harvester
 kubeconfig_test.yaml
+coverage.out
+coverage.html

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -23,7 +23,7 @@ RUN wget --quiet https://github.com/docker/buildx/releases/download/v0.13.1/buil
 ENV DAPPER_RUN_ARGS="--network host -v /run/containerd/containerd.sock:/run/containerd/containerd.sock"
 ENV DAPPER_ENV="REPO TAG DRONE_TAG"
 ENV DAPPER_SOURCE="/go/src/github.com/harvester/terraform-provider-harvester"
-ENV DAPPER_OUTPUT="./bin ./dist ./deploy ./dist ./package ./pkg ./docs ./examples"
+ENV DAPPER_OUTPUT="./bin ./deploy ./dist ./package ./pkg ./docs ./examples ./coverage.html"
 ENV DAPPER_DOCKER_SOCKET=true
 ENV HOME=${DAPPER_SOURCE}
 

--- a/pkg/helper/ip.go
+++ b/pkg/helper/ip.go
@@ -29,8 +29,5 @@ func IsIPv4LinkLocal(ip string) bool {
  * Link-local IPv6 addresses are fe80::/64
  */
 func IsIPv6LinkLocal(ip string) bool {
-	if strings.HasPrefix(strings.ToLower(ip), IPv6LinkLocalCIDRPrefix) {
-		return true
-	}
-	return false
+	return strings.HasPrefix(strings.ToLower(ip), IPv6LinkLocalCIDRPrefix)
 }

--- a/pkg/helper/ip.go
+++ b/pkg/helper/ip.go
@@ -1,0 +1,36 @@
+package helper
+
+import "strings"
+
+const (
+	IPv4LinkLocalCIDRPrefix = "169.254."
+	IPv6LinkLocalCIDRPrefix = "fe80:"
+)
+
+/* Returns true if the argument `ip` is a link-local IPv4 address in the common
+ * CIDR notation
+ *
+ * Link-local IPv4 addresses are 169.254.0.0/16 except 169.254.0.0/24 and
+ * 169.254.255.0/24 according to RFC 3927
+ */
+func IsIPv4LinkLocal(ip string) bool {
+	if strings.HasPrefix(strings.ToLower(ip), IPv4LinkLocalCIDRPrefix) {
+		if !strings.HasPrefix(strings.ToLower(ip), IPv4LinkLocalCIDRPrefix+"0.") &&
+			!strings.HasPrefix(strings.ToLower(ip), IPv4LinkLocalCIDRPrefix+"255.") {
+			return true
+		}
+	}
+	return false
+}
+
+/* Returns true if the argument `ip` is a link-local IPv6 address in the common
+ * CIDR notation
+ *
+ * Link-local IPv6 addresses are fe80::/64
+ */
+func IsIPv6LinkLocal(ip string) bool {
+	if strings.HasPrefix(strings.ToLower(ip), IPv6LinkLocalCIDRPrefix) {
+		return true
+	}
+	return false
+}

--- a/pkg/helper/ip_test.go
+++ b/pkg/helper/ip_test.go
@@ -1,0 +1,129 @@
+package helper
+
+import "testing"
+
+func TestIsIPv4LinkLocal(t *testing.T) {
+	type testcase struct {
+		address     string
+		expectation bool
+	}
+
+	testcases := []testcase{
+		{
+			address:     "",
+			expectation: false,
+		},
+		{
+			address:     "192.168.178.64",
+			expectation: false,
+		},
+		{
+			address:     "127.0.0.1",
+			expectation: false,
+		},
+		{
+			address:     "",
+			expectation: false,
+		},
+		{
+			address:     "2001:9e8:279:b900:21f:bcff:fe13:405/64",
+			expectation: false,
+		},
+		{
+			address:     "fe80::21f:bcff:fe13:405/64",
+			expectation: false,
+		},
+		{
+			address:     "169.254.178.34",
+			expectation: true,
+		},
+		{
+			address:     "169.254.34.98/24",
+			expectation: true,
+		},
+		{
+			address:     "169.254.0.34",
+			expectation: false,
+		},
+		{
+			address:     "169.254.255.98/24",
+			expectation: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		outcome := IsIPv4LinkLocal(tc.address)
+		if outcome != tc.expectation {
+			t.Errorf("unexpected outcome for address %v: %v, expected: %v", tc.address, outcome, tc.expectation)
+		}
+	}
+}
+
+func TestIsIPv6LinkLocal(t *testing.T) {
+	type testcase struct {
+		address     string
+		expectation bool
+	}
+
+	testcases := []testcase{
+		{
+			address:     "",
+			expectation: false,
+		},
+		{
+			address:     "192.168.178.64",
+			expectation: false,
+		},
+		{
+			address:     "127.0.0.1",
+			expectation: false,
+		},
+		{
+			address:     "169.254.178.34",
+			expectation: false,
+		},
+		{
+			address:     "169.254.34.98/64",
+			expectation: false,
+		},
+		{
+			address:     "",
+			expectation: false,
+		},
+		{
+			address:     "2001:9e8:279:b900:21f:bcff:fe13:405/64",
+			expectation: false,
+		},
+		{
+			address:     "fe80::21f:bcff:fe13:405/64",
+			expectation: true,
+		},
+		{
+			address:     "fe80::21f:bcff:fe13:405",
+			expectation: true,
+		},
+		{
+			address:     "fe80::",
+			expectation: true,
+		},
+		{
+			address:     "FE80::21F:BCFF:FE13:405/64",
+			expectation: true,
+		},
+		{
+			address:     "FE80::21F:BCFF:FE13:405",
+			expectation: true,
+		},
+		{
+			address:     "FE80::",
+			expectation: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		outcome := IsIPv6LinkLocal(tc.address)
+		if outcome != tc.expectation {
+			t.Errorf("unexpected outcome for address %v: %v, expected: %v", tc.address, outcome, tc.expectation)
+		}
+	}
+}

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -1,0 +1,404 @@
+package importer
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	"github.com/harvester/harvester/pkg/builder"
+
+	"github.com/harvester/terraform-provider-harvester/pkg/constants"
+)
+
+func TestNetworkInterface(t *testing.T) {
+	type testcase struct {
+		importer    *VMImporter
+		expectation []map[string]interface{}
+		expectError error
+	}
+
+	properties := []string{
+		constants.FieldNetworkInterfaceName,
+		constants.FieldNetworkInterfaceType,
+		constants.FieldNetworkInterfaceModel,
+		constants.FieldNetworkInterfaceMACAddress,
+		constants.FieldNetworkInterfaceNetworkName,
+		constants.FieldNetworkInterfaceBootOrder,
+		constants.FieldNetworkInterfaceIPAddress,
+		constants.FieldNetworkInterfaceInterfaceName,
+		constants.FieldNetworkInterfaceWaitForLease,
+	}
+
+	testcases := []testcase{
+		{
+			// a VM that doesn't have any network interface
+			importer: &VMImporter{
+				VirtualMachine: &kubevirtv1.VirtualMachine{
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{},
+							},
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Domain: kubevirtv1.DomainSpec{
+									Devices: kubevirtv1.Devices{
+										Interfaces: []kubevirtv1.Interface{},
+									},
+								},
+							},
+						},
+					},
+				},
+				VirtualMachineInstance: &kubevirtv1.VirtualMachineInstance{},
+			},
+			expectation: []map[string]interface{}{},
+			expectError: nil,
+		},
+		{
+			// a VM that has a single minimal bridge network interface, but no IP
+			// address
+			importer: &VMImporter{
+				VirtualMachine: &kubevirtv1.VirtualMachine{
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{},
+							},
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Domain: kubevirtv1.DomainSpec{
+									Devices: kubevirtv1.Devices{
+										Interfaces: []kubevirtv1.Interface{
+											{
+												InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
+													Bridge: &kubevirtv1.InterfaceBridge{},
+												},
+												BootOrder: &[]uint{1}[0],
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				VirtualMachineInstance: &kubevirtv1.VirtualMachineInstance{},
+			},
+			expectation: []map[string]interface{}{
+				{
+					constants.FieldNetworkInterfaceName:         "",
+					constants.FieldNetworkInterfaceType:         builder.NetworkInterfaceTypeBridge,
+					constants.FieldNetworkInterfaceModel:        "",
+					constants.FieldNetworkInterfaceMACAddress:   "",
+					constants.FieldNetworkInterfaceNetworkName:  "",
+					constants.FieldNetworkInterfaceBootOrder:    &[]uint{1}[0],
+					constants.FieldNetworkInterfaceWaitForLease: false,
+				},
+			},
+			expectError: nil,
+		},
+		{
+			// a VM that has a single minimal bridge network interface, and only
+			// a link-local IP addresses
+			importer: &VMImporter{
+				VirtualMachine: &kubevirtv1.VirtualMachine{
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{},
+							},
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Domain: kubevirtv1.DomainSpec{
+									Devices: kubevirtv1.Devices{
+										Interfaces: []kubevirtv1.Interface{
+											{
+												Name: "net0",
+												InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
+													Bridge: &kubevirtv1.InterfaceBridge{},
+												},
+												BootOrder: &[]uint{1}[0],
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				VirtualMachineInstance: &kubevirtv1.VirtualMachineInstance{
+					Status: kubevirtv1.VirtualMachineInstanceStatus{
+						Interfaces: []kubevirtv1.VirtualMachineInstanceNetworkInterface{
+							{
+								Name:          "net0",
+								InterfaceName: "eth0",
+								IPs:           []string{"169.254.10.140/24", "fe80::21f:bcff:fe13:405/64"},
+							},
+						},
+					},
+				},
+			},
+			expectation: []map[string]interface{}{
+				{
+					constants.FieldNetworkInterfaceName:         "net0",
+					constants.FieldNetworkInterfaceType:         builder.NetworkInterfaceTypeBridge,
+					constants.FieldNetworkInterfaceModel:        "",
+					constants.FieldNetworkInterfaceMACAddress:   "",
+					constants.FieldNetworkInterfaceNetworkName:  "",
+					constants.FieldNetworkInterfaceBootOrder:    &[]uint{1}[0],
+					constants.FieldNetworkInterfaceWaitForLease: false,
+				},
+			},
+			expectError: nil,
+		},
+		{
+			// a VM that has a single minimal bridge network interface with IP
+			// addresses
+			importer: &VMImporter{
+				VirtualMachine: &kubevirtv1.VirtualMachine{
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{},
+							},
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Domain: kubevirtv1.DomainSpec{
+									Devices: kubevirtv1.Devices{
+										Interfaces: []kubevirtv1.Interface{
+											{
+												Name: "net0",
+												InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
+													Bridge: &kubevirtv1.InterfaceBridge{},
+												},
+												BootOrder: &[]uint{1}[0],
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				VirtualMachineInstance: &kubevirtv1.VirtualMachineInstance{
+					Status: kubevirtv1.VirtualMachineInstanceStatus{
+						Interfaces: []kubevirtv1.VirtualMachineInstanceNetworkInterface{
+							{
+								Name:          "net0",
+								InterfaceName: "eth0",
+								IPs:           []string{"192.168.178.64/24", "fe80::21f:bcff:fe13:405/64"},
+							},
+						},
+					},
+				},
+			},
+			expectation: []map[string]interface{}{
+				{
+					constants.FieldNetworkInterfaceName:          "net0",
+					constants.FieldNetworkInterfaceType:          builder.NetworkInterfaceTypeBridge,
+					constants.FieldNetworkInterfaceModel:         "",
+					constants.FieldNetworkInterfaceMACAddress:    "",
+					constants.FieldNetworkInterfaceNetworkName:   "",
+					constants.FieldNetworkInterfaceBootOrder:     &[]uint{1}[0],
+					constants.FieldNetworkInterfaceWaitForLease:  false,
+					constants.FieldNetworkInterfaceIPAddress:     "192.168.178.64/24",
+					constants.FieldNetworkInterfaceInterfaceName: "eth0",
+				},
+			},
+			expectError: nil,
+		},
+		{
+			// a VM that has multiple minimal bridge network interfaces with several IP
+			// addresses
+			importer: &VMImporter{
+				VirtualMachine: &kubevirtv1.VirtualMachine{
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{},
+							},
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Domain: kubevirtv1.DomainSpec{
+									Devices: kubevirtv1.Devices{
+										Interfaces: []kubevirtv1.Interface{
+											{
+												Name: "net0",
+												InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
+													Bridge: &kubevirtv1.InterfaceBridge{},
+												},
+												BootOrder: &[]uint{1}[0],
+											},
+											{
+												Name: "net1",
+												InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
+													Bridge: &kubevirtv1.InterfaceBridge{},
+												},
+												BootOrder: &[]uint{2}[0],
+											},
+											{
+												Name: "net2",
+												InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
+													Bridge: &kubevirtv1.InterfaceBridge{},
+												},
+												BootOrder: &[]uint{3}[0],
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				VirtualMachineInstance: &kubevirtv1.VirtualMachineInstance{
+					Status: kubevirtv1.VirtualMachineInstanceStatus{
+						Interfaces: []kubevirtv1.VirtualMachineInstanceNetworkInterface{
+							{
+								Name:          "net0",
+								InterfaceName: "eth0",
+								IPs:           []string{"192.168.178.64/24", "fe80::21f:bcff:fe13:405/64"},
+							},
+							{
+								Name:          "net1",
+								InterfaceName: "eth1",
+								IPs:           []string{"fe80::21f:bcff:fe13:406/64"},
+							},
+							{
+								Name:          "net2",
+								InterfaceName: "eth2",
+								IPs:           []string{"192.168.180.64/24", "169.254.180.64/24", "201.168.180.64/24"},
+							},
+						},
+					},
+				},
+			},
+			expectation: []map[string]interface{}{
+				{
+					constants.FieldNetworkInterfaceName:          "net0",
+					constants.FieldNetworkInterfaceType:          builder.NetworkInterfaceTypeBridge,
+					constants.FieldNetworkInterfaceModel:         "",
+					constants.FieldNetworkInterfaceMACAddress:    "",
+					constants.FieldNetworkInterfaceNetworkName:   "",
+					constants.FieldNetworkInterfaceBootOrder:     &[]uint{1}[0],
+					constants.FieldNetworkInterfaceWaitForLease:  false,
+					constants.FieldNetworkInterfaceIPAddress:     "192.168.178.64/24",
+					constants.FieldNetworkInterfaceInterfaceName: "eth0",
+				},
+				{
+					constants.FieldNetworkInterfaceName:         "net1",
+					constants.FieldNetworkInterfaceType:         builder.NetworkInterfaceTypeBridge,
+					constants.FieldNetworkInterfaceModel:        "",
+					constants.FieldNetworkInterfaceMACAddress:   "",
+					constants.FieldNetworkInterfaceNetworkName:  "",
+					constants.FieldNetworkInterfaceBootOrder:    &[]uint{2}[0],
+					constants.FieldNetworkInterfaceWaitForLease: false,
+				},
+				{
+					constants.FieldNetworkInterfaceName:          "net2",
+					constants.FieldNetworkInterfaceType:          builder.NetworkInterfaceTypeBridge,
+					constants.FieldNetworkInterfaceModel:         "",
+					constants.FieldNetworkInterfaceMACAddress:    "",
+					constants.FieldNetworkInterfaceNetworkName:   "",
+					constants.FieldNetworkInterfaceBootOrder:     &[]uint{3}[0],
+					constants.FieldNetworkInterfaceWaitForLease:  false,
+					constants.FieldNetworkInterfaceIPAddress:     "192.168.180.64/24",
+					constants.FieldNetworkInterfaceInterfaceName: "eth2",
+				},
+			},
+			expectError: nil,
+		},
+		{
+			// a VM that has a minimal bridge network interface with multiple IP
+			// addresses in different order
+			importer: &VMImporter{
+				VirtualMachine: &kubevirtv1.VirtualMachine{
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{},
+							},
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Domain: kubevirtv1.DomainSpec{
+									Devices: kubevirtv1.Devices{
+										Interfaces: []kubevirtv1.Interface{
+											{
+												Name: "net0",
+												InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
+													Bridge: &kubevirtv1.InterfaceBridge{},
+												},
+												BootOrder: &[]uint{1}[0],
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				VirtualMachineInstance: &kubevirtv1.VirtualMachineInstance{
+					Status: kubevirtv1.VirtualMachineInstanceStatus{
+						Interfaces: []kubevirtv1.VirtualMachineInstanceNetworkInterface{
+							{
+								Name:          "net0",
+								InterfaceName: "eth0",
+								IPs:           []string{"201.168.180.64/24", "169.254.180.64/24", "192.168.180.64/24"},
+							},
+						},
+					},
+				},
+			},
+			expectation: []map[string]interface{}{
+				{
+					constants.FieldNetworkInterfaceName:          "net0",
+					constants.FieldNetworkInterfaceType:          builder.NetworkInterfaceTypeBridge,
+					constants.FieldNetworkInterfaceModel:         "",
+					constants.FieldNetworkInterfaceMACAddress:    "",
+					constants.FieldNetworkInterfaceNetworkName:   "",
+					constants.FieldNetworkInterfaceBootOrder:     &[]uint{1}[0],
+					constants.FieldNetworkInterfaceWaitForLease:  false,
+					constants.FieldNetworkInterfaceIPAddress:     "192.168.180.64/24",
+					constants.FieldNetworkInterfaceInterfaceName: "eth0",
+				},
+			},
+			expectError: nil,
+		},
+	}
+
+	for _, tc := range testcases {
+		outcome, err := tc.importer.NetworkInterface()
+
+		if err != nil && tc.expectError == nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		if err == nil && tc.expectError != nil {
+			t.Errorf("Expected error %v, got nil", tc.expectError)
+		}
+
+		if len(outcome) != len(tc.expectation) {
+			t.Errorf("Unexpected outcome length: %v, expected %v", len(outcome), len(tc.expectation))
+		}
+
+		for idx, out := range outcome {
+			expect := tc.expectation[idx]
+
+			for _, property := range properties {
+				switch expect[property].(type) {
+				case *uint:
+					o := (out[property].(*uint))
+					e := (expect[property].(*uint))
+					if *o != *e {
+						t.Errorf("Failed Importing NetworkInterface. Value for %v is %v, expeceted %v",
+							property,
+							*o,
+							*e)
+					}
+				default:
+					if out[property] != expect[property] {
+						t.Errorf("Failed Importing NetworkInterface. Value for %v is %v, expeceted %v",
+							property,
+							out[property],
+							expect[property])
+					}
+				}
+			}
+		}
+	}
+}

--- a/scripts/test
+++ b/scripts/test
@@ -14,6 +14,11 @@ echo Running tests:
 go test \
   -v \
   -cover \
+  -coverprofile=coverage.out \
   -tags=test \
   "${EXTRA_OPTIONS[@]}" \
   . ./...
+
+go tool cover \
+  -html=coverage.out \
+  -o coverage.html


### PR DESCRIPTION
Differentiate and ignore link-local IP addresses when importing VM data.

Link-local IP addresses are IPs that the network interface itself selects when no other IP address has been given.
In case ip addresses are assigned using e.g. DHCP, the configuration of a link-local address may happen before the intended IP address is configured.
This results in wrong IP addresses being reported for VMs that are imported by the Terraform provider.

To combat this, the Terraform provider will ignore link-local IP addresses.

Additionally, the Terraform provider will always report the lexicographically lowest IP address for interfaces that have multiple IP addresses.

related-to: harvester/harvester#8900

#### Problem:

The Terraform provider would sometimes import wrong IP addresses, particularly link-local IP addresses. The import also doesn't seem to be stable in the sense that repeatedly importing the same resource would yield different results.

#### Solution:

Ignore link-local IP addresses and ensure that for network interfaces with multiple IP addresses the import always yields the same result.

#### Related Issue(s):

harvester/harvester#8900
SURE-10519

#### Test plan:

Unit tests are included.

Verification steps TBD.

#### Additional documentation or context
