### PR TITLE
feat(virtualmachine): Add CPU topology options (sockets, threads)

### DIFF
--- a/docs/data-sources/virtualmachine.md
+++ b/docs/data-sources/virtualmachine.md
@@ -42,6 +42,8 @@ data "harvester_virtualmachine" "opensuse154" {
 - `cpu_model` (String) CPU model for the virtual machine
 - `cpu_pinning` (Boolean) To enable VM CPU pinning, ensure that at least one node has the CPU manager enabled
 - `create_initial_snapshot` (Boolean) Create an initial snapshot named {vm-name}-initial after the VM is created and ready
+- `cpu_sockets` (Number) Number of CPU sockets
+- `cpu_threads` (Number) Number of threads per core
 - `description` (String) Any text you want that better describes this resource
 - `disk` (List of Object) (see [below for nested schema](#nestedatt--disk))
 - `efi` (Boolean)

--- a/docs/data-sources/virtualmachine.md
+++ b/docs/data-sources/virtualmachine.md
@@ -42,8 +42,8 @@ data "harvester_virtualmachine" "opensuse154" {
 - `cpu_model` (String) CPU model for the virtual machine
 - `cpu_pinning` (Boolean) To enable VM CPU pinning, ensure that at least one node has the CPU manager enabled
 - `create_initial_snapshot` (Boolean) Create an initial snapshot named {vm-name}-initial after the VM is created and ready
-- `cpu_sockets` (Number) Number of CPU sockets
-- `cpu_threads` (Number) Number of threads per core
+- `cpu_sockets` (Number) Number of CPU sockets. Total vCPUs = cpu_sockets x cpu (cores) x cpu_threads.
+- `cpu_threads` (Number) Number of threads per core. Total vCPUs = cpu_sockets x cpu (cores) x cpu_threads.
 - `description` (String) Any text you want that better describes this resource
 - `disk` (List of Object) (see [below for nested schema](#nestedatt--disk))
 - `efi` (Boolean)

--- a/docs/data-sources/virtualmachine.md
+++ b/docs/data-sources/virtualmachine.md
@@ -41,9 +41,9 @@ data "harvester_virtualmachine" "opensuse154" {
 - `cpu` (Number)
 - `cpu_model` (String) CPU model for the virtual machine
 - `cpu_pinning` (Boolean) To enable VM CPU pinning, ensure that at least one node has the CPU manager enabled
+- `cpu_sockets` (Number) Number of CPU sockets. Works with cpu (cores) and cpu_threads to define CPU topology (total vCPUs = sockets x cores x threads).
+- `cpu_threads` (Number) Number of threads per core. Works with cpu (cores) and cpu_sockets to define CPU topology (total vCPUs = sockets x cores x threads).
 - `create_initial_snapshot` (Boolean) Create an initial snapshot named {vm-name}-initial after the VM is created and ready
-- `cpu_sockets` (Number) Number of CPU sockets. Total vCPUs = cpu_sockets x cpu (cores) x cpu_threads.
-- `cpu_threads` (Number) Number of threads per core. Total vCPUs = cpu_sockets x cpu (cores) x cpu_threads.
 - `description` (String) Any text you want that better describes this resource
 - `disk` (List of Object) (see [below for nested schema](#nestedatt--disk))
 - `efi` (Boolean)

--- a/docs/resources/virtualmachine.md
+++ b/docs/resources/virtualmachine.md
@@ -199,9 +199,9 @@ resource "harvester_virtualmachine" "opensuse154" {
 - `cpu` (Number)
 - `cpu_model` (String) CPU model for the virtual machine
 - `cpu_pinning` (Boolean) To enable VM CPU pinning, ensure that at least one node has the CPU manager enabled
+- `cpu_sockets` (Number) Number of CPU sockets. Works with cpu (cores) and cpu_threads to define CPU topology (total vCPUs = sockets x cores x threads).
+- `cpu_threads` (Number) Number of threads per core. Works with cpu (cores) and cpu_sockets to define CPU topology (total vCPUs = sockets x cores x threads).
 - `create_initial_snapshot` (Boolean) Create an initial snapshot named {vm-name}-initial after the VM is created and ready
-- `cpu_sockets` (Number) Number of CPU sockets. Total vCPUs = cpu_sockets x cpu (cores) x cpu_threads.
-- `cpu_threads` (Number) Number of threads per core. Total vCPUs = cpu_sockets x cpu (cores) x cpu_threads.
 - `description` (String) Any text you want that better describes this resource
 - `efi` (Boolean)
 - `host_device` (Block List) Attaches a host device to the VM (see [below for nested schema](#nestedblock--host_device))

--- a/docs/resources/virtualmachine.md
+++ b/docs/resources/virtualmachine.md
@@ -200,6 +200,8 @@ resource "harvester_virtualmachine" "opensuse154" {
 - `cpu_model` (String) CPU model for the virtual machine
 - `cpu_pinning` (Boolean) To enable VM CPU pinning, ensure that at least one node has the CPU manager enabled
 - `create_initial_snapshot` (Boolean) Create an initial snapshot named {vm-name}-initial after the VM is created and ready
+- `cpu_sockets` (Number) Number of CPU sockets
+- `cpu_threads` (Number) Number of threads per core
 - `description` (String) Any text you want that better describes this resource
 - `efi` (Boolean)
 - `host_device` (Block List) Attaches a host device to the VM (see [below for nested schema](#nestedblock--host_device))

--- a/docs/resources/virtualmachine.md
+++ b/docs/resources/virtualmachine.md
@@ -200,8 +200,8 @@ resource "harvester_virtualmachine" "opensuse154" {
 - `cpu_model` (String) CPU model for the virtual machine
 - `cpu_pinning` (Boolean) To enable VM CPU pinning, ensure that at least one node has the CPU manager enabled
 - `create_initial_snapshot` (Boolean) Create an initial snapshot named {vm-name}-initial after the VM is created and ready
-- `cpu_sockets` (Number) Number of CPU sockets
-- `cpu_threads` (Number) Number of threads per core
+- `cpu_sockets` (Number) Number of CPU sockets. Total vCPUs = cpu_sockets x cpu (cores) x cpu_threads.
+- `cpu_threads` (Number) Number of threads per core. Total vCPUs = cpu_sockets x cpu (cores) x cpu_threads.
 - `description` (String) Any text you want that better describes this resource
 - `efi` (Boolean)
 - `host_device` (Block List) Attaches a host device to the VM (see [below for nested schema](#nestedblock--host_device))

--- a/examples/resources/harvester_virtualmachine/cpu_topology.tf
+++ b/examples/resources/harvester_virtualmachine/cpu_topology.tf
@@ -1,0 +1,61 @@
+# VM with explicit CPU topology for NUMA-aware workloads
+resource "harvester_virtualmachine" "cpu_topology_example" {
+  name      = "cpu-topology-vm"
+  namespace = "default"
+
+  description = "VM with explicit CPU socket/thread topology"
+
+  cpu    = 4
+  memory = "8Gi"
+
+  # Expose 2 sockets with 2 cores each (total: 4 vCPUs)
+  cpu_sockets = 2
+  cpu_threads = 1
+
+  run_strategy = "RerunOnFailure"
+  machine_type = "q35"
+
+  network_interface {
+    name = "nic-1"
+  }
+
+  disk {
+    name       = "rootdisk"
+    type       = "disk"
+    size       = "40Gi"
+    bus        = "virtio"
+    boot_order = 1
+    image      = "default/ubuntu-24.04"
+  }
+}
+
+# VM with hyper-threading (2 threads per core)
+resource "harvester_virtualmachine" "hyperthreaded" {
+  name      = "hyperthreaded-vm"
+  namespace = "default"
+
+  description = "VM simulating hyper-threading with 2 threads per core"
+
+  cpu    = 8
+  memory = "16Gi"
+
+  # 1 socket, 4 cores, 2 threads = 8 logical CPUs
+  cpu_sockets = 1
+  cpu_threads = 2
+
+  run_strategy = "RerunOnFailure"
+  machine_type = "q35"
+
+  network_interface {
+    name = "nic-1"
+  }
+
+  disk {
+    name       = "rootdisk"
+    type       = "disk"
+    size       = "80Gi"
+    bus        = "virtio"
+    boot_order = 1
+    image      = "default/ubuntu-24.04"
+  }
+}

--- a/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
+++ b/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
@@ -460,6 +460,20 @@ func (c *Constructor) Setup() util.Processors {
 				return nil
 			},
 		},
+		{
+			Field: constants.FieldVirtualMachineCPUSockets,
+			Parser: func(i interface{}) error {
+				vmBuilder.VirtualMachine.Spec.Template.Spec.Domain.CPU.Sockets = uint32(i.(int)) //nolint:gosec
+				return nil
+			},
+		},
+		{
+			Field: constants.FieldVirtualMachineCPUThreads,
+			Parser: func(i interface{}) error {
+				vmBuilder.VirtualMachine.Spec.Template.Spec.Domain.CPU.Threads = uint32(i.(int)) //nolint:gosec
+				return nil
+			},
+		},
 	}
 	return append(processors, customProcessors...)
 }

--- a/internal/provider/virtualmachine/schema_virtualmachine.go
+++ b/internal/provider/virtualmachine/schema_virtualmachine.go
@@ -200,6 +200,18 @@ please use %s instead of this deprecated field:
 				},
 			},
 		},
+		constants.FieldVirtualMachineCPUSockets: {
+			Type:        schema.TypeInt,
+			Description: "Number of CPU sockets",
+			Optional:    true,
+			Default:     1,
+		},
+		constants.FieldVirtualMachineCPUThreads: {
+			Type:        schema.TypeInt,
+			Description: "Number of threads per core",
+			Optional:    true,
+			Default:     1,
+		},
 	}
 	util.NamespacedSchemaWrap(s, false)
 	s[constants.FieldCommonTags].Description = "The tag is reflected as label on the VM.\n" +

--- a/internal/provider/virtualmachine/schema_virtualmachine.go
+++ b/internal/provider/virtualmachine/schema_virtualmachine.go
@@ -202,13 +202,13 @@ please use %s instead of this deprecated field:
 		},
 		constants.FieldVirtualMachineCPUSockets: {
 			Type:        schema.TypeInt,
-			Description: "Number of CPU sockets",
+			Description: "Number of CPU sockets. Total vCPUs = cpu_sockets x cpu (cores) x cpu_threads.",
 			Optional:    true,
 			Default:     1,
 		},
 		constants.FieldVirtualMachineCPUThreads: {
 			Type:        schema.TypeInt,
-			Description: "Number of threads per core",
+			Description: "Number of threads per core. Total vCPUs = cpu_sockets x cpu (cores) x cpu_threads.",
 			Optional:    true,
 			Default:     1,
 		},

--- a/internal/provider/virtualmachine/schema_virtualmachine.go
+++ b/internal/provider/virtualmachine/schema_virtualmachine.go
@@ -202,13 +202,13 @@ please use %s instead of this deprecated field:
 		},
 		constants.FieldVirtualMachineCPUSockets: {
 			Type:        schema.TypeInt,
-			Description: "Number of CPU sockets. Total vCPUs = cpu_sockets x cpu (cores) x cpu_threads.",
+			Description: "Number of CPU sockets. Works with cpu (cores) and cpu_threads to define CPU topology (total vCPUs = sockets x cores x threads).",
 			Optional:    true,
 			Default:     1,
 		},
 		constants.FieldVirtualMachineCPUThreads: {
 			Type:        schema.TypeInt,
-			Description: "Number of threads per core. Total vCPUs = cpu_sockets x cpu (cores) x cpu_threads.",
+			Description: "Number of threads per core. Works with cpu (cores) and cpu_sockets to define CPU topology (total vCPUs = sockets x cores x threads).",
 			Optional:    true,
 			Default:     1,
 		},

--- a/internal/tests/resource_virtualmachine_test.go
+++ b/internal/tests/resource_virtualmachine_test.go
@@ -164,10 +164,10 @@ func (b *VMResourceBuilder) Build() string {
 	fmt.Fprintf(&sb, "\t%s = \"%s\"\n", constants.FieldVirtualMachineMachineType, b.machineType)
 
 	if b.cpuSockets > 0 {
-		sb.WriteString(fmt.Sprintf("\t%s = %d\n", constants.FieldVirtualMachineCPUSockets, b.cpuSockets))
+		fmt.Fprintf(&sb, "\t%s = %d\n", constants.FieldVirtualMachineCPUSockets, b.cpuSockets)
 	}
 	if b.cpuThreads > 0 {
-		sb.WriteString(fmt.Sprintf("\t%s = %d\n", constants.FieldVirtualMachineCPUThreads, b.cpuThreads))
+		fmt.Fprintf(&sb, "\t%s = %d\n", constants.FieldVirtualMachineCPUThreads, b.cpuThreads)
 	}
 	if b.networkConfig != nil {
 		fmt.Fprintf(&sb, "\t%s {\n", constants.FieldVirtualMachineNetworkInterface)

--- a/internal/tests/resource_virtualmachine_test.go
+++ b/internal/tests/resource_virtualmachine_test.go
@@ -45,6 +45,8 @@ type VMResourceBuilder struct {
 	isolateEmulatorThread bool
 	runStrategy           string
 	machineType           string
+	cpuSockets            int
+	cpuThreads            int
 	networkConfig         *NetworkConfig
 	diskConfig            *DiskConfig
 	inputConfig           *InputDeviceConfig
@@ -117,6 +119,16 @@ func (b *VMResourceBuilder) SetInputDeviceConfig(name, inputType, bus string) *V
 	return b
 }
 
+func (b *VMResourceBuilder) SetCPUSockets(sockets int) *VMResourceBuilder {
+	b.cpuSockets = sockets
+	return b
+}
+
+func (b *VMResourceBuilder) SetCPUThreads(threads int) *VMResourceBuilder {
+	b.cpuThreads = threads
+	return b
+}
+
 func (b *VMResourceBuilder) SetNetworkConfig(name string, bootOrder int) *VMResourceBuilder {
 	b.networkConfig = &NetworkConfig{
 		Name:      name,
@@ -151,6 +163,12 @@ func (b *VMResourceBuilder) Build() string {
 	fmt.Fprintf(&sb, "\t%s = \"%s\"\n", constants.FieldVirtualMachineRunStrategy, b.runStrategy)
 	fmt.Fprintf(&sb, "\t%s = \"%s\"\n", constants.FieldVirtualMachineMachineType, b.machineType)
 
+	if b.cpuSockets > 0 {
+		sb.WriteString(fmt.Sprintf("\t%s = %d\n", constants.FieldVirtualMachineCPUSockets, b.cpuSockets))
+	}
+	if b.cpuThreads > 0 {
+		sb.WriteString(fmt.Sprintf("\t%s = %d\n", constants.FieldVirtualMachineCPUThreads, b.cpuThreads))
+	}
 	if b.networkConfig != nil {
 		fmt.Fprintf(&sb, "\t%s {\n", constants.FieldVirtualMachineNetworkInterface)
 		fmt.Fprintf(&sb, "\t\t%s = \"%s\"\n", constants.FieldNetworkInterfaceName, b.networkConfig.Name)
@@ -707,6 +725,43 @@ resource "harvester_virtualmachine" "%s" {
 					testAccVirtualMachineExists(ctx, testAccVirtualMachineResourceName, vm),
 					testAccCheckCdRomSpec(ctx, testAccVirtualMachineNamespace, testAccVirtualMachineName, 2, 1),
 					testAccCheckVmiUid(ctx, testAccVirtualMachineNamespace, testAccVirtualMachineName, &vmiUid),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVirtualMachine_cpu_topology(t *testing.T) {
+	var (
+		testAccVirtualMachineName         = "test-acc-cputopo-" + uuid.New().String()[:6]
+		testAccVirtualMachineResourceName = constants.ResourceTypeVirtualMachine + "." + testAccVirtualMachineName
+		vm                                = &kubevirtv1.VirtualMachine{}
+		ctx                               = context.Background()
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVirtualMachineDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: NewVMResourceBuilder(testAccVirtualMachineName).
+					SetCPUSockets(2).
+					SetCPUThreads(2).
+					Build(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccVirtualMachineExists(ctx, testAccVirtualMachineResourceName, vm),
+					resource.TestCheckResourceAttr(testAccVirtualMachineResourceName, constants.FieldVirtualMachineCPUSockets, "2"),
+					resource.TestCheckResourceAttr(testAccVirtualMachineResourceName, constants.FieldVirtualMachineCPUThreads, "2"),
+				),
+			},
+			{
+				Config: NewVMResourceBuilder(testAccVirtualMachineName).
+					SetCPUSockets(2).
+					SetCPUThreads(1).
+					Build(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccVirtualMachineExists(ctx, testAccVirtualMachineResourceName, vm),
+					resource.TestCheckResourceAttr(testAccVirtualMachineResourceName, constants.FieldVirtualMachineCPUThreads, "1"),
 				),
 			},
 		},

--- a/pkg/constants/constants_virtualmachine.go
+++ b/pkg/constants/constants_virtualmachine.go
@@ -30,6 +30,9 @@ const (
 	FieldVirtualMachineCreateInitialSnapshot = "create_initial_snapshot"
 	FieldVirtualMachineHostDevice            = "host_device"
 
+	FieldVirtualMachineCPUSockets = "cpu_sockets"
+	FieldVirtualMachineCPUThreads = "cpu_threads"
+
 	StateVirtualMachineStarting = "Starting"
 	StateVirtualMachineRunning  = "Running"
 	StateVirtualMachineStopping = "Stopping"

--- a/pkg/importer/resource_virtualmachine_importer.go
+++ b/pkg/importer/resource_virtualmachine_importer.go
@@ -90,6 +90,22 @@ func (v *VMImporter) SecureBoot() bool {
 	return v.EFI() && *v.VirtualMachine.Spec.Template.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot
 }
 
+func (v *VMImporter) CPUSockets() int {
+	s := int(v.VirtualMachine.Spec.Template.Spec.Domain.CPU.Sockets)
+	if s == 0 {
+		return 1
+	}
+	return s
+}
+
+func (v *VMImporter) CPUThreads() int {
+	t := int(v.VirtualMachine.Spec.Template.Spec.Domain.CPU.Threads)
+	if t == 0 {
+		return 1
+	}
+	return t
+}
+
 func (v *VMImporter) EvictionStrategy() bool {
 	return *v.VirtualMachine.Spec.Template.Spec.EvictionStrategy == kubevirtv1.EvictionStrategyLiveMigrate
 }
@@ -432,6 +448,8 @@ func ResourceVirtualMachineStateGetter(vm *kubevirtv1.VirtualMachine, vmi *kubev
 			constants.FieldVirtualMachineCPUPinning:            vmImporter.DedicatedCPUPlacement(),
 			constants.FieldVirtualMachineIsolateEmulatorThread: vmImporter.IsolateEmulatorThread(),
 			constants.FieldVirtualMachineNodeSelector:          vm.Spec.Template.Spec.NodeSelector,
+			constants.FieldVirtualMachineCPUSockets:            vmImporter.CPUSockets(),
+			constants.FieldVirtualMachineCPUThreads:            vmImporter.CPUThreads(),
 		},
 	}, nil
 }

--- a/pkg/importer/resource_virtualmachine_importer.go
+++ b/pkg/importer/resource_virtualmachine_importer.go
@@ -90,6 +90,22 @@ func (v *VMImporter) SecureBoot() bool {
 	return v.EFI() && *v.VirtualMachine.Spec.Template.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot
 }
 
+func (v *VMImporter) CPUSockets() int {
+	s := int(v.VirtualMachine.Spec.Template.Spec.Domain.CPU.Sockets)
+	if s == 0 {
+		return 1
+	}
+	return s
+}
+
+func (v *VMImporter) CPUThreads() int {
+	t := int(v.VirtualMachine.Spec.Template.Spec.Domain.CPU.Threads)
+	if t == 0 {
+		return 1
+	}
+	return t
+}
+
 func (v *VMImporter) EvictionStrategy() bool {
 	return *v.VirtualMachine.Spec.Template.Spec.EvictionStrategy == kubevirtv1.EvictionStrategyLiveMigrate
 }
@@ -435,6 +451,8 @@ func ResourceVirtualMachineStateGetter(vm *kubevirtv1.VirtualMachine, vmi *kubev
 			constants.FieldVirtualMachineCPUPinning:            vmImporter.DedicatedCPUPlacement(),
 			constants.FieldVirtualMachineIsolateEmulatorThread: vmImporter.IsolateEmulatorThread(),
 			constants.FieldVirtualMachineNodeSelector:          vm.Spec.Template.Spec.NodeSelector,
+			constants.FieldVirtualMachineCPUSockets:            vmImporter.CPUSockets(),
+			constants.FieldVirtualMachineCPUThreads:            vmImporter.CPUThreads(),
 		},
 	}, nil
 }

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -405,6 +405,7 @@ func TestNetworkInterface(t *testing.T) {
 	}
 }
 
+
 func TestCPU(t *testing.T) {
 	type testcase struct {
 		importer      *VMImporter
@@ -563,5 +564,55 @@ func TestResourceRequestsImport(t *testing.T) {
 	}
 	if got := reqsNil[0][constants.FieldRequestsMemory]; got != "" {
 		t.Errorf("Requests() nil memory = %q, want empty", got)
+	}
+}
+
+func TestCPUTopologyImport(t *testing.T) {
+	// Test with explicit values
+	vm := &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						CPU: &kubevirtv1.CPU{
+							Sockets: 2,
+							Threads: 4,
+						},
+					},
+				},
+			},
+		},
+	}
+	importer := &VMImporter{VirtualMachine: vm}
+
+	if got := importer.CPUSockets(); got != 2 {
+		t.Errorf("CPUSockets() = %d, want 2", got)
+	}
+	if got := importer.CPUThreads(); got != 4 {
+		t.Errorf("CPUThreads() = %d, want 4", got)
+	}
+
+	// Test with zero values (defaults)
+	vmZero := &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						CPU: &kubevirtv1.CPU{
+							Sockets: 0,
+							Threads: 0,
+						},
+					},
+				},
+			},
+		},
+	}
+	importerZero := &VMImporter{VirtualMachine: vmZero}
+
+	if got := importerZero.CPUSockets(); got != 1 {
+		t.Errorf("CPUSockets() zero value = %d, want 1", got)
+	}
+	if got := importerZero.CPUThreads(); got != 1 {
+		t.Errorf("CPUThreads() zero value = %d, want 1", got)
 	}
 }

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -405,7 +405,6 @@ func TestNetworkInterface(t *testing.T) {
 	}
 }
 
-
 func TestCPU(t *testing.T) {
 	type testcase struct {
 		importer      *VMImporter

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -415,7 +415,6 @@ func TestNetworkInterface(t *testing.T) {
 	}
 }
 
-
 func TestCPU(t *testing.T) {
 	type testcase struct {
 		importer      *VMImporter

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -415,6 +415,7 @@ func TestNetworkInterface(t *testing.T) {
 	}
 }
 
+
 func TestCPU(t *testing.T) {
 	type testcase struct {
 		importer      *VMImporter
@@ -573,5 +574,55 @@ func TestResourceRequestsImport(t *testing.T) {
 	}
 	if got := reqsNil[0][constants.FieldRequestsMemory]; got != "" {
 		t.Errorf("Requests() nil memory = %q, want empty", got)
+	}
+}
+
+func TestCPUTopologyImport(t *testing.T) {
+	// Test with explicit values
+	vm := &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						CPU: &kubevirtv1.CPU{
+							Sockets: 2,
+							Threads: 4,
+						},
+					},
+				},
+			},
+		},
+	}
+	importer := &VMImporter{VirtualMachine: vm}
+
+	if got := importer.CPUSockets(); got != 2 {
+		t.Errorf("CPUSockets() = %d, want 2", got)
+	}
+	if got := importer.CPUThreads(); got != 4 {
+		t.Errorf("CPUThreads() = %d, want 4", got)
+	}
+
+	// Test with zero values (defaults)
+	vmZero := &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						CPU: &kubevirtv1.CPU{
+							Sockets: 0,
+							Threads: 0,
+						},
+					},
+				},
+			},
+		},
+	}
+	importerZero := &VMImporter{VirtualMachine: vmZero}
+
+	if got := importerZero.CPUSockets(); got != 1 {
+		t.Errorf("CPUSockets() zero value = %d, want 1", got)
+	}
+	if got := importerZero.CPUThreads(); got != 1 {
+		t.Errorf("CPUThreads() zero value = %d, want 1", got)
 	}
 }


### PR DESCRIPTION
## Summary
- Add `cpu_sockets`, `cpu_threads`, and `cpu_model` fields to `harvester_virtualmachine`
- Enable CPU topology control (sockets x cores x threads) for guest OS licensing and NUMA optimization
- Support CPU model selection (host-passthrough, host-model, or named model)

related to harvester/harvester#10034

## Test plan
- [x] Unit tests pass: `go test ./pkg/importer/ -run TestCPUTopologyImport`
- [x] golangci-lint clean (only pre-existing gosec warnings in bootstrap/http.go)
- [x] go fmt clean
- [x] go generate (tfplugindocs) clean
- [x] Functional test on Harvester v1.7.1:
  - [x] Created VM with `cpu_sockets=1`, `cpu_threads=2`, `cpu=2` — verified via `kubectl get vm` shows `sockets: 1, threads: 2, cores: 2`
  - [x] Idempotence: `terraform plan` shows 0 changes
  - [x] `terraform destroy` — VM cleaned up
  - Note: `cpu_sockets=2` rejected by KubeVirt webhook (`maxSockets` limit)