### PR TITLE
feat(virtualmachine): Add eviction strategy, grace period, and OS type

### DIFF
--- a/docs/data-sources/virtualmachine.md
+++ b/docs/data-sources/virtualmachine.md
@@ -46,6 +46,7 @@ data "harvester_virtualmachine" "opensuse154" {
 - `disk` (List of Object) (see [below for nested schema](#nestedatt--disk))
 - `efi` (Boolean)
 - `host_device` (List of Object) Attaches a host device to the VM (see [below for nested schema](#nestedatt--host_device))
+- `eviction_strategy` (String) Eviction strategy for the VM (None, LiveMigrate, LiveMigrateIfPossible, External)
 - `hostname` (String)
 - `id` (String) The ID of this resource.
 - `input` (List of Object) (see [below for nested schema](#nestedatt--input))
@@ -57,11 +58,12 @@ data "harvester_virtualmachine" "opensuse154" {
 - `network_interface` (List of Object) (see [below for nested schema](#nestedatt--network_interface))
 - `node_name` (String)
 - `node_selector` (Map of String) Node selector for scheduling the VM. The key is the label key and the value is the label value.
-- `requests` (List of Object) Resource requests for the VM. When unset, Harvester's overcommit webhook manages these values. (see [below for nested schema](#nestedatt--requests))
+- `os_type` (String) OS type annotation for KVM guest optimizations (e.g. linux, windows)
 - `reserved_memory` (String)
 - `restart_after_update` (Boolean) restart vm after the vm is updated
 - `run_strategy` (String) more info: https://kubevirt.io/user-guide/virtual_machines/run_strategies/
 - `secure_boot` (Boolean) EFI must be enabled to use this feature
+- `termination_grace_period_seconds` (Number) Grace period in seconds before the VM is forcefully terminated
 - `ssh_keys` (List of String) The `ssh_keys` are added to `cloudinit.user_data` if:
 1. Both `cloudinit.user_data_base64` and `cloudinit.user_data_secret_name` are empty.
 2. There is no `ssh_authorized_keys` field in `cloudinit.user_data`.
@@ -143,15 +145,6 @@ Read-Only:
 - `network_name` (String)
 - `type` (String)
 - `wait_for_lease` (Boolean)
-
-
-<a id="nestedatt--requests"></a>
-### Nested Schema for `requests`
-
-Read-Only:
-
-- `cpu` (String)
-- `memory` (String)
 
 
 <a id="nestedatt--tpm"></a>

--- a/docs/data-sources/virtualmachine.md
+++ b/docs/data-sources/virtualmachine.md
@@ -59,11 +59,11 @@ data "harvester_virtualmachine" "opensuse154" {
 - `node_name` (String)
 - `node_selector` (Map of String) Node selector for scheduling the VM. The key is the label key and the value is the label value.
 - `os_type` (String) OS type annotation for KVM guest optimizations (e.g. linux, windows)
+- `requests` (List of Object) Resource requests for the VM. When unset, Harvester's overcommit webhook manages these values. (see [below for nested schema](#nestedatt--requests))
 - `reserved_memory` (String)
 - `restart_after_update` (Boolean) restart vm after the vm is updated
 - `run_strategy` (String) more info: https://kubevirt.io/user-guide/virtual_machines/run_strategies/
 - `secure_boot` (Boolean) EFI must be enabled to use this feature
-- `termination_grace_period_seconds` (Number) Grace period in seconds before the VM is forcefully terminated
 - `ssh_keys` (List of String) The `ssh_keys` are added to `cloudinit.user_data` if:
 1. Both `cloudinit.user_data_base64` and `cloudinit.user_data_secret_name` are empty.
 2. There is no `ssh_authorized_keys` field in `cloudinit.user_data`.
@@ -74,6 +74,7 @@ For example: `sample-tag = sample` adds label `tag.harvesterhci.io/sample-tag: s
 For `ssh-user` tag, the value is added to `cloudinit.user_data` if:
 1. Both `cloudinit.user_data_base64` and `cloudinit.user_data_secret_name` are empty.
 2. There is no `user` field in `cloudinit.user_data`.
+- `termination_grace_period_seconds` (Number) Grace period in seconds before the VM is forcefully terminated
 - `tpm` (List of Object) (see [below for nested schema](#nestedatt--tpm))
 
 <a id="nestedatt--cloudinit"></a>
@@ -145,6 +146,15 @@ Read-Only:
 - `network_name` (String)
 - `type` (String)
 - `wait_for_lease` (Boolean)
+
+
+<a id="nestedatt--requests"></a>
+### Nested Schema for `requests`
+
+Read-Only:
+
+- `cpu` (String)
+- `memory` (String)
 
 
 <a id="nestedatt--tpm"></a>

--- a/docs/data-sources/virtualmachine.md
+++ b/docs/data-sources/virtualmachine.md
@@ -45,8 +45,8 @@ data "harvester_virtualmachine" "opensuse154" {
 - `description` (String) Any text you want that better describes this resource
 - `disk` (List of Object) (see [below for nested schema](#nestedatt--disk))
 - `efi` (Boolean)
-- `host_device` (List of Object) Attaches a host device to the VM (see [below for nested schema](#nestedatt--host_device))
 - `eviction_strategy` (String) Eviction strategy for the VM (None, LiveMigrate, LiveMigrateIfPossible, External)
+- `host_device` (List of Object) Attaches a host device to the VM (see [below for nested schema](#nestedatt--host_device))
 - `hostname` (String)
 - `id` (String) The ID of this resource.
 - `input` (List of Object) (see [below for nested schema](#nestedatt--input))

--- a/docs/resources/virtualmachine.md
+++ b/docs/resources/virtualmachine.md
@@ -202,8 +202,8 @@ resource "harvester_virtualmachine" "opensuse154" {
 - `create_initial_snapshot` (Boolean) Create an initial snapshot named {vm-name}-initial after the VM is created and ready
 - `description` (String) Any text you want that better describes this resource
 - `efi` (Boolean)
-- `host_device` (Block List) Attaches a host device to the VM (see [below for nested schema](#nestedblock--host_device))
 - `eviction_strategy` (String) Eviction strategy for the VM (None, LiveMigrate, LiveMigrateIfPossible, External)
+- `host_device` (Block List) Attaches a host device to the VM (see [below for nested schema](#nestedblock--host_device))
 - `hostname` (String)
 - `input` (Block List) (see [below for nested schema](#nestedblock--input))
 - `isolate_emulator_thread` (Boolean) To enable isolate emulator thread, ensure that at least one node has the CPU manager enabled, also VM CPU pinning must be enabled. Note that enable option will allocate an additional dedicated CPU.

--- a/docs/resources/virtualmachine.md
+++ b/docs/resources/virtualmachine.md
@@ -203,6 +203,7 @@ resource "harvester_virtualmachine" "opensuse154" {
 - `description` (String) Any text you want that better describes this resource
 - `efi` (Boolean)
 - `host_device` (Block List) Attaches a host device to the VM (see [below for nested schema](#nestedblock--host_device))
+- `eviction_strategy` (String) Eviction strategy for the VM (None, LiveMigrate, LiveMigrateIfPossible, External)
 - `hostname` (String)
 - `input` (Block List) (see [below for nested schema](#nestedblock--input))
 - `isolate_emulator_thread` (Boolean) To enable isolate emulator thread, ensure that at least one node has the CPU manager enabled, also VM CPU pinning must be enabled. Note that enable option will allocate an additional dedicated CPU.
@@ -211,11 +212,12 @@ resource "harvester_virtualmachine" "opensuse154" {
 - `memory` (String)
 - `namespace` (String)
 - `node_selector` (Map of String) Node selector for scheduling the VM. The key is the label key and the value is the label value.
-- `requests` (Block List, Max: 1) Resource requests for the VM. When unset, Harvester's overcommit webhook manages these values. (see [below for nested schema](#nestedblock--requests))
+- `os_type` (String) OS type annotation for KVM guest optimizations (e.g. linux, windows)
 - `reserved_memory` (String)
 - `restart_after_update` (Boolean) restart vm after the vm is updated
 - `run_strategy` (String) more info: https://kubevirt.io/user-guide/virtual_machines/run_strategies/
 - `secure_boot` (Boolean) EFI must be enabled to use this feature
+- `termination_grace_period_seconds` (Number) Grace period in seconds before the VM is forcefully terminated
 - `ssh_keys` (List of String) The `ssh_keys` are added to `cloudinit.user_data` if:
 1. Both `cloudinit.user_data_base64` and `cloudinit.user_data_secret_name` are empty.
 2. There is no `ssh_authorized_keys` field in `cloudinit.user_data`.
@@ -316,15 +318,6 @@ Optional:
 
 - `bus` (String)
 - `type` (String)
-
-
-<a id="nestedblock--requests"></a>
-### Nested Schema for `requests`
-
-Optional:
-
-- `cpu` (String) CPU request as Kubernetes quantity (e.g. 1, 500m).
-- `memory` (String) Memory request as Kubernetes quantity (e.g. 512Mi, 1Gi).
 
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/resources/virtualmachine.md
+++ b/docs/resources/virtualmachine.md
@@ -213,11 +213,11 @@ resource "harvester_virtualmachine" "opensuse154" {
 - `namespace` (String)
 - `node_selector` (Map of String) Node selector for scheduling the VM. The key is the label key and the value is the label value.
 - `os_type` (String) OS type annotation for KVM guest optimizations (e.g. linux, windows)
+- `requests` (Block List, Max: 1) Resource requests for the VM. When unset, Harvester's overcommit webhook manages these values. (see [below for nested schema](#nestedblock--requests))
 - `reserved_memory` (String)
 - `restart_after_update` (Boolean) restart vm after the vm is updated
 - `run_strategy` (String) more info: https://kubevirt.io/user-guide/virtual_machines/run_strategies/
 - `secure_boot` (Boolean) EFI must be enabled to use this feature
-- `termination_grace_period_seconds` (Number) Grace period in seconds before the VM is forcefully terminated
 - `ssh_keys` (List of String) The `ssh_keys` are added to `cloudinit.user_data` if:
 1. Both `cloudinit.user_data_base64` and `cloudinit.user_data_secret_name` are empty.
 2. There is no `ssh_authorized_keys` field in `cloudinit.user_data`.
@@ -227,6 +227,7 @@ For example: `sample-tag = sample` adds label `tag.harvesterhci.io/sample-tag: s
 For `ssh-user` tag, the value is added to `cloudinit.user_data` if:
 1. Both `cloudinit.user_data_base64` and `cloudinit.user_data_secret_name` are empty.
 2. There is no `user` field in `cloudinit.user_data`.
+- `termination_grace_period_seconds` (Number) Grace period in seconds before the VM is forcefully terminated
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `tpm` (Block List, Max: 1) (see [below for nested schema](#nestedblock--tpm))
 
@@ -318,6 +319,15 @@ Optional:
 
 - `bus` (String)
 - `type` (String)
+
+
+<a id="nestedblock--requests"></a>
+### Nested Schema for `requests`
+
+Optional:
+
+- `cpu` (String) CPU request as Kubernetes quantity (e.g. 1, 500m).
+- `memory` (String) Memory request as Kubernetes quantity (e.g. 512Mi, 1Gi).
 
 
 <a id="nestedblock--timeouts"></a>

--- a/examples/resources/harvester_virtualmachine/vm_runtime.tf
+++ b/examples/resources/harvester_virtualmachine/vm_runtime.tf
@@ -1,0 +1,69 @@
+# VM with runtime options for production workloads
+resource "harvester_virtualmachine" "production" {
+  name      = "production-app"
+  namespace = "default"
+
+  description = "Production VM with eviction strategy and graceful shutdown"
+
+  cpu    = 4
+  memory = "8Gi"
+
+  run_strategy = "RerunOnFailure"
+  machine_type = "q35"
+
+  # Live-migrate on node drain or resource pressure
+  eviction_strategy = "LiveMigrate"
+
+  # Allow 5 minutes for graceful shutdown
+  termination_grace_period_seconds = 300
+
+  # OS type hint for KubeVirt optimizations
+  os_type = "linux"
+
+  network_interface {
+    name = "nic-1"
+  }
+
+  disk {
+    name       = "rootdisk"
+    type       = "disk"
+    size       = "40Gi"
+    bus        = "virtio"
+    boot_order = 1
+    image      = "default/ubuntu-24.04"
+  }
+}
+
+# Windows VM with appropriate runtime settings
+resource "harvester_virtualmachine" "windows_runtime" {
+  name      = "windows-server"
+  namespace = "default"
+
+  description = "Windows Server with extended shutdown grace period"
+
+  cpu    = 4
+  memory = "8Gi"
+
+  run_strategy = "RerunOnFailure"
+  machine_type = "q35"
+
+  eviction_strategy = "LiveMigrate"
+
+  # Windows needs more time for graceful shutdown
+  termination_grace_period_seconds = 600
+
+  os_type = "windows"
+
+  network_interface {
+    name = "nic-1"
+  }
+
+  disk {
+    name       = "rootdisk"
+    type       = "disk"
+    size       = "80Gi"
+    bus        = "virtio"
+    boot_order = 1
+    image      = "default/windows-server-2025"
+  }
+}

--- a/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
+++ b/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
@@ -484,12 +484,9 @@ func (c *Constructor) Setup() util.Processors {
 					vmBuilder.Annotations(map[string]string{
 						constants.AnnotationOSType: osType,
 					})
-				} else {
-					delete(vmBuilder.VirtualMachine.Annotations, constants.AnnotationOSType)
 				}
 				return nil
 			},
-			Required: true,
 		},
 	}
 	return append(processors, customProcessors...)

--- a/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
+++ b/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
@@ -460,6 +460,37 @@ func (c *Constructor) Setup() util.Processors {
 				return nil
 			},
 		},
+		{
+			Field: constants.FieldVirtualMachineEvictionStrategy,
+			Parser: func(i interface{}) error {
+				strategy := kubevirtv1.EvictionStrategy(i.(string))
+				vmBuilder.VirtualMachine.Spec.Template.Spec.EvictionStrategy = &strategy
+				return nil
+			},
+		},
+		{
+			Field: constants.FieldVirtualMachineTerminationGracePeriodSeconds,
+			Parser: func(i interface{}) error {
+				seconds := int64(i.(int))
+				vmBuilder.VirtualMachine.Spec.Template.Spec.TerminationGracePeriodSeconds = &seconds
+				return nil
+			},
+		},
+		{
+			Field: constants.FieldVirtualMachineOSType,
+			Parser: func(i interface{}) error {
+				osType := i.(string)
+				if osType != "" {
+					vmBuilder.Annotations(map[string]string{
+						constants.AnnotationOSType: osType,
+					})
+				} else {
+					delete(vmBuilder.VirtualMachine.Annotations, constants.AnnotationOSType)
+				}
+				return nil
+			},
+			Required: true,
+		},
 	}
 	return append(processors, customProcessors...)
 }
@@ -491,7 +522,6 @@ func newVMConstructor(c *client.Client, ctx context.Context, vmBuilder *builder.
 func Creator(c *client.Client, ctx context.Context, namespace, name string) util.Constructor {
 	vmBuilder := builder.NewVMBuilder(vmCreator).
 		Namespace(namespace).Name(name).
-		EvictionStrategy(true).
 		DefaultPodAntiAffinity()
 	return newVMConstructor(c, ctx, vmBuilder)
 }

--- a/internal/provider/virtualmachine/schema_virtualmachine.go
+++ b/internal/provider/virtualmachine/schema_virtualmachine.go
@@ -200,6 +200,30 @@ please use %s instead of this deprecated field:
 				},
 			},
 		},
+		constants.FieldVirtualMachineEvictionStrategy: {
+			Type:        schema.TypeString,
+			Description: "Eviction strategy for the VM (None, LiveMigrate, LiveMigrateIfPossible, External)",
+			Optional:    true,
+			Default:     "LiveMigrateIfPossible",
+			ValidateFunc: validation.StringInSlice([]string{
+				"None",
+				"LiveMigrate",
+				"LiveMigrateIfPossible",
+				"External",
+			}, false),
+		},
+		constants.FieldVirtualMachineTerminationGracePeriodSeconds: {
+			Type:        schema.TypeInt,
+			Description: "Grace period in seconds before the VM is forcefully terminated",
+			Optional:    true,
+			Default:     30,
+		},
+		constants.FieldVirtualMachineOSType: {
+			Type:        schema.TypeString,
+			Description: "OS type annotation for KVM guest optimizations (e.g. linux, windows)",
+			Optional:    true,
+			Computed:    true,
+		},
 	}
 	util.NamespacedSchemaWrap(s, false)
 	s[constants.FieldCommonTags].Description = "The tag is reflected as label on the VM.\n" +

--- a/internal/provider/virtualmachine/schema_virtualmachine.go
+++ b/internal/provider/virtualmachine/schema_virtualmachine.go
@@ -204,7 +204,7 @@ please use %s instead of this deprecated field:
 			Type:        schema.TypeString,
 			Description: "Eviction strategy for the VM (None, LiveMigrate, LiveMigrateIfPossible, External)",
 			Optional:    true,
-			Default:     "LiveMigrateIfPossible",
+			Default:     constants.DefaultEvictionStrategy,
 			ValidateFunc: validation.StringInSlice([]string{
 				"None",
 				"LiveMigrate",
@@ -216,7 +216,7 @@ please use %s instead of this deprecated field:
 			Type:         schema.TypeInt,
 			Description:  "Grace period in seconds before the VM is forcefully terminated",
 			Optional:     true,
-			Default:      30,
+			Default:      constants.DefaultTerminationGracePeriodSeconds,
 			ValidateFunc: validation.IntAtLeast(0),
 		},
 		constants.FieldVirtualMachineOSType: {

--- a/internal/provider/virtualmachine/schema_virtualmachine.go
+++ b/internal/provider/virtualmachine/schema_virtualmachine.go
@@ -213,10 +213,11 @@ please use %s instead of this deprecated field:
 			}, false),
 		},
 		constants.FieldVirtualMachineTerminationGracePeriodSeconds: {
-			Type:        schema.TypeInt,
-			Description: "Grace period in seconds before the VM is forcefully terminated",
-			Optional:    true,
-			Default:     30,
+			Type:         schema.TypeInt,
+			Description:  "Grace period in seconds before the VM is forcefully terminated",
+			Optional:     true,
+			Default:      30,
+			ValidateFunc: validation.IntAtLeast(0),
 		},
 		constants.FieldVirtualMachineOSType: {
 			Type:        schema.TypeString,

--- a/internal/tests/resource_virtualmachine_test.go
+++ b/internal/tests/resource_virtualmachine_test.go
@@ -46,7 +46,7 @@ type VMResourceBuilder struct {
 	runStrategy                   string
 	machineType                   string
 	evictionStrategy              string
-	terminationGracePeriodSeconds int
+	terminationGracePeriodSeconds *int
 	osType                        string
 	networkConfig                 *NetworkConfig
 	diskConfig                    *DiskConfig
@@ -126,7 +126,7 @@ func (b *VMResourceBuilder) SetEvictionStrategy(strategy string) *VMResourceBuil
 }
 
 func (b *VMResourceBuilder) SetTerminationGracePeriodSeconds(seconds int) *VMResourceBuilder {
-	b.terminationGracePeriodSeconds = seconds
+	b.terminationGracePeriodSeconds = &seconds
 	return b
 }
 
@@ -172,8 +172,8 @@ func (b *VMResourceBuilder) Build() string {
 	if b.evictionStrategy != "" {
 		sb.WriteString(fmt.Sprintf("\t%s = \"%s\"\n", constants.FieldVirtualMachineEvictionStrategy, b.evictionStrategy))
 	}
-	if b.terminationGracePeriodSeconds > 0 {
-		sb.WriteString(fmt.Sprintf("\t%s = %d\n", constants.FieldVirtualMachineTerminationGracePeriodSeconds, b.terminationGracePeriodSeconds))
+	if b.terminationGracePeriodSeconds != nil {
+		sb.WriteString(fmt.Sprintf("\t%s = %d\n", constants.FieldVirtualMachineTerminationGracePeriodSeconds, *b.terminationGracePeriodSeconds))
 	}
 	if b.osType != "" {
 		sb.WriteString(fmt.Sprintf("\t%s = \"%s\"\n", constants.FieldVirtualMachineOSType, b.osType))

--- a/internal/tests/resource_virtualmachine_test.go
+++ b/internal/tests/resource_virtualmachine_test.go
@@ -170,13 +170,13 @@ func (b *VMResourceBuilder) Build() string {
 	fmt.Fprintf(&sb, "\t%s = \"%s\"\n", constants.FieldVirtualMachineMachineType, b.machineType)
 
 	if b.evictionStrategy != "" {
-		sb.WriteString(fmt.Sprintf("\t%s = \"%s\"\n", constants.FieldVirtualMachineEvictionStrategy, b.evictionStrategy))
+		fmt.Fprintf(&sb, "\t%s = \"%s\"\n", constants.FieldVirtualMachineEvictionStrategy, b.evictionStrategy)
 	}
 	if b.terminationGracePeriodSeconds != nil {
-		sb.WriteString(fmt.Sprintf("\t%s = %d\n", constants.FieldVirtualMachineTerminationGracePeriodSeconds, *b.terminationGracePeriodSeconds))
+		fmt.Fprintf(&sb, "\t%s = %d\n", constants.FieldVirtualMachineTerminationGracePeriodSeconds, *b.terminationGracePeriodSeconds)
 	}
 	if b.osType != "" {
-		sb.WriteString(fmt.Sprintf("\t%s = \"%s\"\n", constants.FieldVirtualMachineOSType, b.osType))
+		fmt.Fprintf(&sb, "\t%s = \"%s\"\n", constants.FieldVirtualMachineOSType, b.osType)
 	}
 
 	if b.networkConfig != nil {

--- a/internal/tests/resource_virtualmachine_test.go
+++ b/internal/tests/resource_virtualmachine_test.go
@@ -37,17 +37,20 @@ const (
 )
 
 type VMResourceBuilder struct {
-	name                  string
-	description           string
-	cpu                   int
-	memory                string // e.g. "1Gi"
-	cpuPinning            bool
-	isolateEmulatorThread bool
-	runStrategy           string
-	machineType           string
-	networkConfig         *NetworkConfig
-	diskConfig            *DiskConfig
-	inputConfig           *InputDeviceConfig
+	name                          string
+	description                   string
+	cpu                           int
+	memory                        string // e.g. "1Gi"
+	cpuPinning                    bool
+	isolateEmulatorThread         bool
+	runStrategy                   string
+	machineType                   string
+	evictionStrategy              string
+	terminationGracePeriodSeconds int
+	osType                        string
+	networkConfig                 *NetworkConfig
+	diskConfig                    *DiskConfig
+	inputConfig                   *InputDeviceConfig
 }
 
 type DiskConfig struct {
@@ -117,6 +120,21 @@ func (b *VMResourceBuilder) SetInputDeviceConfig(name, inputType, bus string) *V
 	return b
 }
 
+func (b *VMResourceBuilder) SetEvictionStrategy(strategy string) *VMResourceBuilder {
+	b.evictionStrategy = strategy
+	return b
+}
+
+func (b *VMResourceBuilder) SetTerminationGracePeriodSeconds(seconds int) *VMResourceBuilder {
+	b.terminationGracePeriodSeconds = seconds
+	return b
+}
+
+func (b *VMResourceBuilder) SetOSType(osType string) *VMResourceBuilder {
+	b.osType = osType
+	return b
+}
+
 func (b *VMResourceBuilder) SetNetworkConfig(name string, bootOrder int) *VMResourceBuilder {
 	b.networkConfig = &NetworkConfig{
 		Name:      name,
@@ -150,6 +168,16 @@ func (b *VMResourceBuilder) Build() string {
 	fmt.Fprintf(&sb, "\t%s = %s\n", constants.FieldVirtualMachineIsolateEmulatorThread, strconv.FormatBool(b.isolateEmulatorThread))
 	fmt.Fprintf(&sb, "\t%s = \"%s\"\n", constants.FieldVirtualMachineRunStrategy, b.runStrategy)
 	fmt.Fprintf(&sb, "\t%s = \"%s\"\n", constants.FieldVirtualMachineMachineType, b.machineType)
+
+	if b.evictionStrategy != "" {
+		sb.WriteString(fmt.Sprintf("\t%s = \"%s\"\n", constants.FieldVirtualMachineEvictionStrategy, b.evictionStrategy))
+	}
+	if b.terminationGracePeriodSeconds > 0 {
+		sb.WriteString(fmt.Sprintf("\t%s = %d\n", constants.FieldVirtualMachineTerminationGracePeriodSeconds, b.terminationGracePeriodSeconds))
+	}
+	if b.osType != "" {
+		sb.WriteString(fmt.Sprintf("\t%s = \"%s\"\n", constants.FieldVirtualMachineOSType, b.osType))
+	}
 
 	if b.networkConfig != nil {
 		fmt.Fprintf(&sb, "\t%s {\n", constants.FieldVirtualMachineNetworkInterface)
@@ -707,6 +735,46 @@ resource "harvester_virtualmachine" "%s" {
 					testAccVirtualMachineExists(ctx, testAccVirtualMachineResourceName, vm),
 					testAccCheckCdRomSpec(ctx, testAccVirtualMachineNamespace, testAccVirtualMachineName, 2, 1),
 					testAccCheckVmiUid(ctx, testAccVirtualMachineNamespace, testAccVirtualMachineName, &vmiUid),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVirtualMachine_runtime_options(t *testing.T) {
+	var (
+		testAccVirtualMachineName         = "test-acc-runtime-" + uuid.New().String()[:6]
+		testAccVirtualMachineResourceName = constants.ResourceTypeVirtualMachine + "." + testAccVirtualMachineName
+		vm                                = &kubevirtv1.VirtualMachine{}
+		ctx                               = context.Background()
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVirtualMachineDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: NewVMResourceBuilder(testAccVirtualMachineName).
+					SetEvictionStrategy("LiveMigrateIfPossible").
+					SetTerminationGracePeriodSeconds(60).
+					SetOSType("linux").
+					Build(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccVirtualMachineExists(ctx, testAccVirtualMachineResourceName, vm),
+					resource.TestCheckResourceAttr(testAccVirtualMachineResourceName, constants.FieldVirtualMachineEvictionStrategy, "LiveMigrateIfPossible"),
+					resource.TestCheckResourceAttr(testAccVirtualMachineResourceName, constants.FieldVirtualMachineTerminationGracePeriodSeconds, "60"),
+					resource.TestCheckResourceAttr(testAccVirtualMachineResourceName, constants.FieldVirtualMachineOSType, "linux"),
+				),
+			},
+			{
+				Config: NewVMResourceBuilder(testAccVirtualMachineName).
+					SetEvictionStrategy("None").
+					SetTerminationGracePeriodSeconds(60).
+					SetOSType("linux").
+					Build(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccVirtualMachineExists(ctx, testAccVirtualMachineResourceName, vm),
+					resource.TestCheckResourceAttr(testAccVirtualMachineResourceName, constants.FieldVirtualMachineEvictionStrategy, "None"),
 				),
 			},
 		},

--- a/pkg/constants/constants_virtualmachine.go
+++ b/pkg/constants/constants_virtualmachine.go
@@ -36,6 +36,9 @@ const (
 
 	AnnotationOSType = "harvesterhci.io/os"
 
+	DefaultEvictionStrategy              = "LiveMigrateIfPossible"
+	DefaultTerminationGracePeriodSeconds = 30
+
 	StateVirtualMachineStarting = "Starting"
 	StateVirtualMachineRunning  = "Running"
 	StateVirtualMachineStopping = "Stopping"

--- a/pkg/constants/constants_virtualmachine.go
+++ b/pkg/constants/constants_virtualmachine.go
@@ -30,6 +30,12 @@ const (
 	FieldVirtualMachineCreateInitialSnapshot = "create_initial_snapshot"
 	FieldVirtualMachineHostDevice            = "host_device"
 
+	FieldVirtualMachineEvictionStrategy              = "eviction_strategy"
+	FieldVirtualMachineTerminationGracePeriodSeconds = "termination_grace_period_seconds"
+	FieldVirtualMachineOSType                        = "os_type"
+
+	AnnotationOSType = "harvesterhci.io/os"
+
 	StateVirtualMachineStarting = "Starting"
 	StateVirtualMachineRunning  = "Running"
 	StateVirtualMachineStopping = "Stopping"

--- a/pkg/importer/resource_virtualmachine_importer.go
+++ b/pkg/importer/resource_virtualmachine_importer.go
@@ -92,14 +92,14 @@ func (v *VMImporter) SecureBoot() bool {
 
 func (v *VMImporter) EvictionStrategy() string {
 	if v.VirtualMachine.Spec.Template.Spec.EvictionStrategy == nil {
-		return "LiveMigrateIfPossible"
+		return constants.DefaultEvictionStrategy
 	}
 	return string(*v.VirtualMachine.Spec.Template.Spec.EvictionStrategy)
 }
 
 func (v *VMImporter) TerminationGracePeriodSeconds() int {
 	if v.VirtualMachine.Spec.Template.Spec.TerminationGracePeriodSeconds == nil {
-		return 30
+		return constants.DefaultTerminationGracePeriodSeconds
 	}
 	return int(*v.VirtualMachine.Spec.Template.Spec.TerminationGracePeriodSeconds)
 }

--- a/pkg/importer/resource_virtualmachine_importer.go
+++ b/pkg/importer/resource_virtualmachine_importer.go
@@ -90,8 +90,22 @@ func (v *VMImporter) SecureBoot() bool {
 	return v.EFI() && *v.VirtualMachine.Spec.Template.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot
 }
 
-func (v *VMImporter) EvictionStrategy() bool {
-	return *v.VirtualMachine.Spec.Template.Spec.EvictionStrategy == kubevirtv1.EvictionStrategyLiveMigrate
+func (v *VMImporter) EvictionStrategy() string {
+	if v.VirtualMachine.Spec.Template.Spec.EvictionStrategy == nil {
+		return "LiveMigrateIfPossible"
+	}
+	return string(*v.VirtualMachine.Spec.Template.Spec.EvictionStrategy)
+}
+
+func (v *VMImporter) TerminationGracePeriodSeconds() int {
+	if v.VirtualMachine.Spec.Template.Spec.TerminationGracePeriodSeconds == nil {
+		return 30
+	}
+	return int(*v.VirtualMachine.Spec.Template.Spec.TerminationGracePeriodSeconds)
+}
+
+func (v *VMImporter) OSType() string {
+	return v.VirtualMachine.Annotations[constants.AnnotationOSType]
 }
 
 func (v *VMImporter) SSHKeys() ([]string, error) {
@@ -432,6 +446,10 @@ func ResourceVirtualMachineStateGetter(vm *kubevirtv1.VirtualMachine, vmi *kubev
 			constants.FieldVirtualMachineCPUPinning:            vmImporter.DedicatedCPUPlacement(),
 			constants.FieldVirtualMachineIsolateEmulatorThread: vmImporter.IsolateEmulatorThread(),
 			constants.FieldVirtualMachineNodeSelector:          vm.Spec.Template.Spec.NodeSelector,
+
+			constants.FieldVirtualMachineEvictionStrategy:              vmImporter.EvictionStrategy(),
+			constants.FieldVirtualMachineTerminationGracePeriodSeconds: vmImporter.TerminationGracePeriodSeconds(),
+			constants.FieldVirtualMachineOSType:                        vmImporter.OSType(),
 		},
 	}, nil
 }

--- a/pkg/importer/resource_virtualmachine_importer.go
+++ b/pkg/importer/resource_virtualmachine_importer.go
@@ -90,8 +90,22 @@ func (v *VMImporter) SecureBoot() bool {
 	return v.EFI() && *v.VirtualMachine.Spec.Template.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot
 }
 
-func (v *VMImporter) EvictionStrategy() bool {
-	return *v.VirtualMachine.Spec.Template.Spec.EvictionStrategy == kubevirtv1.EvictionStrategyLiveMigrate
+func (v *VMImporter) EvictionStrategy() string {
+	if v.VirtualMachine.Spec.Template.Spec.EvictionStrategy == nil {
+		return "LiveMigrateIfPossible"
+	}
+	return string(*v.VirtualMachine.Spec.Template.Spec.EvictionStrategy)
+}
+
+func (v *VMImporter) TerminationGracePeriodSeconds() int {
+	if v.VirtualMachine.Spec.Template.Spec.TerminationGracePeriodSeconds == nil {
+		return 30
+	}
+	return int(*v.VirtualMachine.Spec.Template.Spec.TerminationGracePeriodSeconds)
+}
+
+func (v *VMImporter) OSType() string {
+	return v.VirtualMachine.Annotations[constants.AnnotationOSType]
 }
 
 func (v *VMImporter) SSHKeys() ([]string, error) {
@@ -435,6 +449,10 @@ func ResourceVirtualMachineStateGetter(vm *kubevirtv1.VirtualMachine, vmi *kubev
 			constants.FieldVirtualMachineCPUPinning:            vmImporter.DedicatedCPUPlacement(),
 			constants.FieldVirtualMachineIsolateEmulatorThread: vmImporter.IsolateEmulatorThread(),
 			constants.FieldVirtualMachineNodeSelector:          vm.Spec.Template.Spec.NodeSelector,
+
+			constants.FieldVirtualMachineEvictionStrategy:              vmImporter.EvictionStrategy(),
+			constants.FieldVirtualMachineTerminationGracePeriodSeconds: vmImporter.TerminationGracePeriodSeconds(),
+			constants.FieldVirtualMachineOSType:                        vmImporter.OSType(),
 		},
 	}, nil
 }

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -618,11 +618,11 @@ func TestVMRuntimeImport(t *testing.T) {
 	}
 	importerNil := &VMImporter{VirtualMachine: vmNil}
 
-	if got := importerNil.EvictionStrategy(); got != "LiveMigrateIfPossible" {
-		t.Errorf("EvictionStrategy() nil = %q, want %q", got, "LiveMigrateIfPossible")
+	if got := importerNil.EvictionStrategy(); got != constants.DefaultEvictionStrategy {
+		t.Errorf("EvictionStrategy() nil = %q, want %q", got, constants.DefaultEvictionStrategy)
 	}
-	if got := importerNil.TerminationGracePeriodSeconds(); got != 30 {
-		t.Errorf("TerminationGracePeriodSeconds() nil = %d, want 30", got)
+	if got := importerNil.TerminationGracePeriodSeconds(); got != constants.DefaultTerminationGracePeriodSeconds {
+		t.Errorf("TerminationGracePeriodSeconds() nil = %d, want %d", got, constants.DefaultTerminationGracePeriodSeconds)
 	}
 	if got := importerNil.OSType(); got != "" {
 		t.Errorf("OSType() nil = %q, want %q", got, "")

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -405,6 +405,7 @@ func TestNetworkInterface(t *testing.T) {
 	}
 }
 
+
 func TestCPU(t *testing.T) {
 	type testcase struct {
 		importer      *VMImporter
@@ -563,5 +564,67 @@ func TestResourceRequestsImport(t *testing.T) {
 	}
 	if got := reqsNil[0][constants.FieldRequestsMemory]; got != "" {
 		t.Errorf("Requests() nil memory = %q, want empty", got)
+	}
+}
+
+func TestVMRuntimeImport(t *testing.T) {
+	// Test with explicit values
+	strategy := kubevirtv1.EvictionStrategy("LiveMigrate")
+	grace := int64(60)
+	vm := &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				constants.AnnotationOSType: "linux",
+			},
+		},
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					EvictionStrategy:              &strategy,
+					TerminationGracePeriodSeconds: &grace,
+					Domain: kubevirtv1.DomainSpec{
+						CPU: &kubevirtv1.CPU{},
+					},
+				},
+			},
+		},
+	}
+	importer := &VMImporter{VirtualMachine: vm}
+
+	if got := importer.EvictionStrategy(); got != "LiveMigrate" {
+		t.Errorf("EvictionStrategy() = %q, want %q", got, "LiveMigrate")
+	}
+	if got := importer.TerminationGracePeriodSeconds(); got != 60 {
+		t.Errorf("TerminationGracePeriodSeconds() = %d, want 60", got)
+	}
+	if got := importer.OSType(); got != "linux" {
+		t.Errorf("OSType() = %q, want %q", got, "linux")
+	}
+
+	// Test with nil values (defaults)
+	vmNil := &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{},
+		},
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						CPU: &kubevirtv1.CPU{},
+					},
+				},
+			},
+		},
+	}
+	importerNil := &VMImporter{VirtualMachine: vmNil}
+
+	if got := importerNil.EvictionStrategy(); got != "LiveMigrateIfPossible" {
+		t.Errorf("EvictionStrategy() nil = %q, want %q", got, "LiveMigrateIfPossible")
+	}
+	if got := importerNil.TerminationGracePeriodSeconds(); got != 30 {
+		t.Errorf("TerminationGracePeriodSeconds() nil = %d, want 30", got)
+	}
+	if got := importerNil.OSType(); got != "" {
+		t.Errorf("OSType() nil = %q, want %q", got, "")
 	}
 }

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -405,7 +405,6 @@ func TestNetworkInterface(t *testing.T) {
 	}
 }
 
-
 func TestCPU(t *testing.T) {
 	type testcase struct {
 		importer      *VMImporter

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -415,7 +415,6 @@ func TestNetworkInterface(t *testing.T) {
 	}
 }
 
-
 func TestCPU(t *testing.T) {
 	type testcase struct {
 		importer      *VMImporter

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -628,11 +628,11 @@ func TestVMRuntimeImport(t *testing.T) {
 	}
 	importerNil := &VMImporter{VirtualMachine: vmNil}
 
-	if got := importerNil.EvictionStrategy(); got != "LiveMigrateIfPossible" {
-		t.Errorf("EvictionStrategy() nil = %q, want %q", got, "LiveMigrateIfPossible")
+	if got := importerNil.EvictionStrategy(); got != constants.DefaultEvictionStrategy {
+		t.Errorf("EvictionStrategy() nil = %q, want %q", got, constants.DefaultEvictionStrategy)
 	}
-	if got := importerNil.TerminationGracePeriodSeconds(); got != 30 {
-		t.Errorf("TerminationGracePeriodSeconds() nil = %d, want 30", got)
+	if got := importerNil.TerminationGracePeriodSeconds(); got != constants.DefaultTerminationGracePeriodSeconds {
+		t.Errorf("TerminationGracePeriodSeconds() nil = %d, want %d", got, constants.DefaultTerminationGracePeriodSeconds)
 	}
 	if got := importerNil.OSType(); got != "" {
 		t.Errorf("OSType() nil = %q, want %q", got, "")

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -415,6 +415,7 @@ func TestNetworkInterface(t *testing.T) {
 	}
 }
 
+
 func TestCPU(t *testing.T) {
 	type testcase struct {
 		importer      *VMImporter
@@ -573,5 +574,67 @@ func TestResourceRequestsImport(t *testing.T) {
 	}
 	if got := reqsNil[0][constants.FieldRequestsMemory]; got != "" {
 		t.Errorf("Requests() nil memory = %q, want empty", got)
+	}
+}
+
+func TestVMRuntimeImport(t *testing.T) {
+	// Test with explicit values
+	strategy := kubevirtv1.EvictionStrategy("LiveMigrate")
+	grace := int64(60)
+	vm := &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				constants.AnnotationOSType: "linux",
+			},
+		},
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					EvictionStrategy:              &strategy,
+					TerminationGracePeriodSeconds: &grace,
+					Domain: kubevirtv1.DomainSpec{
+						CPU: &kubevirtv1.CPU{},
+					},
+				},
+			},
+		},
+	}
+	importer := &VMImporter{VirtualMachine: vm}
+
+	if got := importer.EvictionStrategy(); got != "LiveMigrate" {
+		t.Errorf("EvictionStrategy() = %q, want %q", got, "LiveMigrate")
+	}
+	if got := importer.TerminationGracePeriodSeconds(); got != 60 {
+		t.Errorf("TerminationGracePeriodSeconds() = %d, want 60", got)
+	}
+	if got := importer.OSType(); got != "linux" {
+		t.Errorf("OSType() = %q, want %q", got, "linux")
+	}
+
+	// Test with nil values (defaults)
+	vmNil := &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{},
+		},
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						CPU: &kubevirtv1.CPU{},
+					},
+				},
+			},
+		},
+	}
+	importerNil := &VMImporter{VirtualMachine: vmNil}
+
+	if got := importerNil.EvictionStrategy(); got != "LiveMigrateIfPossible" {
+		t.Errorf("EvictionStrategy() nil = %q, want %q", got, "LiveMigrateIfPossible")
+	}
+	if got := importerNil.TerminationGracePeriodSeconds(); got != 30 {
+		t.Errorf("TerminationGracePeriodSeconds() nil = %d, want 30", got)
+	}
+	if got := importerNil.OSType(); got != "" {
+		t.Errorf("OSType() nil = %q, want %q", got, "")
 	}
 }


### PR DESCRIPTION
## Summary
- Make eviction strategy configurable (was hardcoded to LiveMigrateIfPossible)
- Add `termination_grace_period_seconds` for graceful shutdown control
- Add `os_type` annotation for KVM guest optimizations

related to harvester/harvester#10035

## Test plan
- [x] Unit tests pass: `go test ./pkg/importer/ -run TestVMRuntimeImport`
- [x] golangci-lint clean (only pre-existing gosec warnings in bootstrap/http.go)
- [x] go fmt clean
- [x] go generate (tfplugindocs) clean
- [x] Functional test on Harvester v1.7.1:
  - [x] Created VM with `eviction_strategy=None`, `termination_grace_period_seconds=60` — verified via `kubectl get vm`
  - [x] `os_type` computed field reads correctly (empty when no annotation set)
  - [x] Idempotence: `terraform plan` shows 0 changes
  - [x] `terraform destroy` — VM cleaned up