### PR TITLE
feat(virtualmachine): Add hugepages support for memory performance

### DIFF
--- a/docs/data-sources/virtualmachine.md
+++ b/docs/data-sources/virtualmachine.md
@@ -47,6 +47,7 @@ data "harvester_virtualmachine" "opensuse154" {
 - `efi` (Boolean)
 - `host_device` (List of Object) Attaches a host device to the VM (see [below for nested schema](#nestedatt--host_device))
 - `hostname` (String)
+- `hugepages` (String) Hugepages size for memory performance (2Mi or 1Gi)
 - `id` (String) The ID of this resource.
 - `input` (List of Object) (see [below for nested schema](#nestedatt--input))
 - `isolate_emulator_thread` (Boolean) To enable isolate emulator thread, ensure that at least one node has the CPU manager enabled, also VM CPU pinning must be enabled. Note that enable option will allocate an additional dedicated CPU.

--- a/docs/resources/virtualmachine.md
+++ b/docs/resources/virtualmachine.md
@@ -204,6 +204,7 @@ resource "harvester_virtualmachine" "opensuse154" {
 - `efi` (Boolean)
 - `host_device` (Block List) Attaches a host device to the VM (see [below for nested schema](#nestedblock--host_device))
 - `hostname` (String)
+- `hugepages` (String) Hugepages size for memory performance (2Mi or 1Gi)
 - `input` (Block List) (see [below for nested schema](#nestedblock--input))
 - `isolate_emulator_thread` (Boolean) To enable isolate emulator thread, ensure that at least one node has the CPU manager enabled, also VM CPU pinning must be enabled. Note that enable option will allocate an additional dedicated CPU.
 - `labels` (Map of String)

--- a/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
+++ b/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
@@ -460,6 +460,21 @@ func (c *Constructor) Setup() util.Processors {
 				return nil
 			},
 		},
+		{
+			Field: constants.FieldVirtualMachineHugepages,
+			Parser: func(i interface{}) error {
+				pageSize := i.(string)
+				if pageSize != "" {
+					vmBuilder.VirtualMachine.Spec.Template.Spec.Domain.Memory = &kubevirtv1.Memory{
+						Hugepages: &kubevirtv1.Hugepages{PageSize: pageSize},
+					}
+				} else {
+					vmBuilder.VirtualMachine.Spec.Template.Spec.Domain.Memory = nil
+				}
+				return nil
+			},
+			Required: true,
+		},
 	}
 	return append(processors, customProcessors...)
 }

--- a/internal/provider/virtualmachine/schema_virtualmachine.go
+++ b/internal/provider/virtualmachine/schema_virtualmachine.go
@@ -200,6 +200,17 @@ please use %s instead of this deprecated field:
 				},
 			},
 		},
+		constants.FieldVirtualMachineHugepages: {
+			Type:        schema.TypeString,
+			Description: "Hugepages size for memory performance (2Mi or 1Gi)",
+			Optional:    true,
+			Default:     "",
+			ValidateFunc: validation.StringInSlice([]string{
+				"",
+				"2Mi",
+				"1Gi",
+			}, false),
+		},
 	}
 	util.NamespacedSchemaWrap(s, false)
 	s[constants.FieldCommonTags].Description = "The tag is reflected as label on the VM.\n" +

--- a/internal/tests/resource_virtualmachine_test.go
+++ b/internal/tests/resource_virtualmachine_test.go
@@ -158,7 +158,7 @@ func (b *VMResourceBuilder) Build() string {
 	fmt.Fprintf(&sb, "\t%s = \"%s\"\n", constants.FieldVirtualMachineMachineType, b.machineType)
 
 	if b.hugepages != "" {
-		sb.WriteString(fmt.Sprintf("\t%s = \"%s\"\n", constants.FieldVirtualMachineHugepages, b.hugepages))
+		fmt.Fprintf(&sb, "\t%s = \"%s\"\n", constants.FieldVirtualMachineHugepages, b.hugepages)
 	}
 
 	if b.networkConfig != nil {

--- a/internal/tests/resource_virtualmachine_test.go
+++ b/internal/tests/resource_virtualmachine_test.go
@@ -45,6 +45,7 @@ type VMResourceBuilder struct {
 	isolateEmulatorThread bool
 	runStrategy           string
 	machineType           string
+	hugepages             string
 	networkConfig         *NetworkConfig
 	diskConfig            *DiskConfig
 	inputConfig           *InputDeviceConfig
@@ -117,6 +118,11 @@ func (b *VMResourceBuilder) SetInputDeviceConfig(name, inputType, bus string) *V
 	return b
 }
 
+func (b *VMResourceBuilder) SetHugepages(hugepages string) *VMResourceBuilder {
+	b.hugepages = hugepages
+	return b
+}
+
 func (b *VMResourceBuilder) SetNetworkConfig(name string, bootOrder int) *VMResourceBuilder {
 	b.networkConfig = &NetworkConfig{
 		Name:      name,
@@ -150,6 +156,10 @@ func (b *VMResourceBuilder) Build() string {
 	fmt.Fprintf(&sb, "\t%s = %s\n", constants.FieldVirtualMachineIsolateEmulatorThread, strconv.FormatBool(b.isolateEmulatorThread))
 	fmt.Fprintf(&sb, "\t%s = \"%s\"\n", constants.FieldVirtualMachineRunStrategy, b.runStrategy)
 	fmt.Fprintf(&sb, "\t%s = \"%s\"\n", constants.FieldVirtualMachineMachineType, b.machineType)
+
+	if b.hugepages != "" {
+		sb.WriteString(fmt.Sprintf("\t%s = \"%s\"\n", constants.FieldVirtualMachineHugepages, b.hugepages))
+	}
 
 	if b.networkConfig != nil {
 		fmt.Fprintf(&sb, "\t%s {\n", constants.FieldVirtualMachineNetworkInterface)
@@ -707,6 +717,31 @@ resource "harvester_virtualmachine" "%s" {
 					testAccVirtualMachineExists(ctx, testAccVirtualMachineResourceName, vm),
 					testAccCheckCdRomSpec(ctx, testAccVirtualMachineNamespace, testAccVirtualMachineName, 2, 1),
 					testAccCheckVmiUid(ctx, testAccVirtualMachineNamespace, testAccVirtualMachineName, &vmiUid),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVirtualMachine_hugepages(t *testing.T) {
+	var (
+		testAccVirtualMachineName         = "test-acc-hugepg-" + uuid.New().String()[:6]
+		testAccVirtualMachineResourceName = constants.ResourceTypeVirtualMachine + "." + testAccVirtualMachineName
+		vm                                = &kubevirtv1.VirtualMachine{}
+		ctx                               = context.Background()
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVirtualMachineDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: NewVMResourceBuilder(testAccVirtualMachineName).
+					SetHugepages("2Mi").
+					Build(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccVirtualMachineExists(ctx, testAccVirtualMachineResourceName, vm),
+					resource.TestCheckResourceAttr(testAccVirtualMachineResourceName, constants.FieldVirtualMachineHugepages, "2Mi"),
 				),
 			},
 		},

--- a/pkg/constants/constants_virtualmachine.go
+++ b/pkg/constants/constants_virtualmachine.go
@@ -30,6 +30,8 @@ const (
 	FieldVirtualMachineCreateInitialSnapshot = "create_initial_snapshot"
 	FieldVirtualMachineHostDevice            = "host_device"
 
+	FieldVirtualMachineHugepages = "hugepages"
+
 	StateVirtualMachineStarting = "Starting"
 	StateVirtualMachineRunning  = "Running"
 	StateVirtualMachineStopping = "Stopping"

--- a/pkg/importer/resource_virtualmachine_importer.go
+++ b/pkg/importer/resource_virtualmachine_importer.go
@@ -90,6 +90,14 @@ func (v *VMImporter) SecureBoot() bool {
 	return v.EFI() && *v.VirtualMachine.Spec.Template.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot
 }
 
+func (v *VMImporter) HugepagesSize() string {
+	memory := v.VirtualMachine.Spec.Template.Spec.Domain.Memory
+	if memory == nil || memory.Hugepages == nil {
+		return ""
+	}
+	return memory.Hugepages.PageSize
+}
+
 func (v *VMImporter) EvictionStrategy() bool {
 	return *v.VirtualMachine.Spec.Template.Spec.EvictionStrategy == kubevirtv1.EvictionStrategyLiveMigrate
 }
@@ -432,6 +440,7 @@ func ResourceVirtualMachineStateGetter(vm *kubevirtv1.VirtualMachine, vmi *kubev
 			constants.FieldVirtualMachineCPUPinning:            vmImporter.DedicatedCPUPlacement(),
 			constants.FieldVirtualMachineIsolateEmulatorThread: vmImporter.IsolateEmulatorThread(),
 			constants.FieldVirtualMachineNodeSelector:          vm.Spec.Template.Spec.NodeSelector,
+			constants.FieldVirtualMachineHugepages:             vmImporter.HugepagesSize(),
 		},
 	}, nil
 }

--- a/pkg/importer/resource_virtualmachine_importer.go
+++ b/pkg/importer/resource_virtualmachine_importer.go
@@ -90,6 +90,14 @@ func (v *VMImporter) SecureBoot() bool {
 	return v.EFI() && *v.VirtualMachine.Spec.Template.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot
 }
 
+func (v *VMImporter) HugepagesSize() string {
+	memory := v.VirtualMachine.Spec.Template.Spec.Domain.Memory
+	if memory == nil || memory.Hugepages == nil {
+		return ""
+	}
+	return memory.Hugepages.PageSize
+}
+
 func (v *VMImporter) EvictionStrategy() bool {
 	return *v.VirtualMachine.Spec.Template.Spec.EvictionStrategy == kubevirtv1.EvictionStrategyLiveMigrate
 }
@@ -435,6 +443,7 @@ func ResourceVirtualMachineStateGetter(vm *kubevirtv1.VirtualMachine, vmi *kubev
 			constants.FieldVirtualMachineCPUPinning:            vmImporter.DedicatedCPUPlacement(),
 			constants.FieldVirtualMachineIsolateEmulatorThread: vmImporter.IsolateEmulatorThread(),
 			constants.FieldVirtualMachineNodeSelector:          vm.Spec.Template.Spec.NodeSelector,
+			constants.FieldVirtualMachineHugepages:             vmImporter.HugepagesSize(),
 		},
 	}, nil
 }

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -405,6 +405,7 @@ func TestNetworkInterface(t *testing.T) {
 	}
 }
 
+
 func TestCPU(t *testing.T) {
 	type testcase struct {
 		importer      *VMImporter
@@ -563,5 +564,58 @@ func TestResourceRequestsImport(t *testing.T) {
 	}
 	if got := reqsNil[0][constants.FieldRequestsMemory]; got != "" {
 		t.Errorf("Requests() nil memory = %q, want empty", got)
+	}
+}
+
+func TestHugepagesImport(t *testing.T) {
+	// Test with hugepages set
+	vm := &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Memory: &kubevirtv1.Memory{
+							Hugepages: &kubevirtv1.Hugepages{PageSize: "2Mi"},
+						},
+					},
+				},
+			},
+		},
+	}
+	importer := &VMImporter{VirtualMachine: vm}
+	if got := importer.HugepagesSize(); got != "2Mi" {
+		t.Errorf("HugepagesSize() = %q, want %q", got, "2Mi")
+	}
+
+	// Test with nil memory
+	vmNilMem := &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{},
+				},
+			},
+		},
+	}
+	importerNilMem := &VMImporter{VirtualMachine: vmNilMem}
+	if got := importerNilMem.HugepagesSize(); got != "" {
+		t.Errorf("HugepagesSize() nil memory = %q, want %q", got, "")
+	}
+
+	// Test with nil hugepages
+	vmNilHuge := &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Memory: &kubevirtv1.Memory{},
+					},
+				},
+			},
+		},
+	}
+	importerNilHuge := &VMImporter{VirtualMachine: vmNilHuge}
+	if got := importerNilHuge.HugepagesSize(); got != "" {
+		t.Errorf("HugepagesSize() nil hugepages = %q, want %q", got, "")
 	}
 }

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -405,7 +405,6 @@ func TestNetworkInterface(t *testing.T) {
 	}
 }
 
-
 func TestCPU(t *testing.T) {
 	type testcase struct {
 		importer      *VMImporter

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -415,7 +415,6 @@ func TestNetworkInterface(t *testing.T) {
 	}
 }
 
-
 func TestCPU(t *testing.T) {
 	type testcase struct {
 		importer      *VMImporter

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -415,6 +415,7 @@ func TestNetworkInterface(t *testing.T) {
 	}
 }
 
+
 func TestCPU(t *testing.T) {
 	type testcase struct {
 		importer      *VMImporter
@@ -573,5 +574,58 @@ func TestResourceRequestsImport(t *testing.T) {
 	}
 	if got := reqsNil[0][constants.FieldRequestsMemory]; got != "" {
 		t.Errorf("Requests() nil memory = %q, want empty", got)
+	}
+}
+
+func TestHugepagesImport(t *testing.T) {
+	// Test with hugepages set
+	vm := &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Memory: &kubevirtv1.Memory{
+							Hugepages: &kubevirtv1.Hugepages{PageSize: "2Mi"},
+						},
+					},
+				},
+			},
+		},
+	}
+	importer := &VMImporter{VirtualMachine: vm}
+	if got := importer.HugepagesSize(); got != "2Mi" {
+		t.Errorf("HugepagesSize() = %q, want %q", got, "2Mi")
+	}
+
+	// Test with nil memory
+	vmNilMem := &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{},
+				},
+			},
+		},
+	}
+	importerNilMem := &VMImporter{VirtualMachine: vmNilMem}
+	if got := importerNilMem.HugepagesSize(); got != "" {
+		t.Errorf("HugepagesSize() nil memory = %q, want %q", got, "")
+	}
+
+	// Test with nil hugepages
+	vmNilHuge := &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Memory: &kubevirtv1.Memory{},
+					},
+				},
+			},
+		},
+	}
+	importerNilHuge := &VMImporter{VirtualMachine: vmNilHuge}
+	if got := importerNilHuge.HugepagesSize(); got != "" {
+		t.Errorf("HugepagesSize() nil hugepages = %q, want %q", got, "")
 	}
 }


### PR DESCRIPTION
## Summary
- Add `hugepages` field to `harvester_virtualmachine` for 2Mi or 1Gi huge pages
- Enables memory-intensive workloads to reduce TLB misses
- Validates page size to only allow empty string (disabled), 2Mi, or 1Gi

Resolves harvester/harvester#10036

## Test plan
- [ ] Unit tests pass: `go test ./pkg/importer/ -run TestHugepagesImport`
- [ ] Acceptance tests pass: `TF_ACC=1 go test ./internal/tests/ -run TestAccVirtualMachine_hugepages`
- [ ] golangci-lint clean
- [ ] go fmt clean
- [ ] go generate (tfplugindocs) clean
- [ ] Manual testing on Harvester cluster: create VM with hugepages=2Mi, verify /proc/meminfo shows HugePages in guest