### PR TITLE
fix linter warnings

### DIFF
--- a/internal/provider/bootstrap/resource_bootstrap.go
+++ b/internal/provider/bootstrap/resource_bootstrap.go
@@ -26,7 +26,7 @@ const (
 
 type loginRequestPayload struct {
 	Username     string `json:"username"`
-	Password     string `json:"password"`
+	Password     string `json:"password"` //nolint:gosec
 	ResponseType string `json:"responseType"`
 	TTL          int    `json:"ttl"`
 	Description  string `json:"description"`
@@ -35,7 +35,7 @@ type loginRequestPayload struct {
 type loginResponsePayload struct {
 	ID    string `json:"id"`
 	Type  string `json:"type"`
-	Token string `json:"token"`
+	Token string `json:"token"` //nolint:gosec
 	Code  string `json:"code"`
 }
 

--- a/internal/tests/resource_virtualmachine_test.go
+++ b/internal/tests/resource_virtualmachine_test.go
@@ -139,40 +139,40 @@ func (b *VMResourceBuilder) SetDiskConfig(name, bus, image string, bootOrder int
 // Build generates the terraform resource string.
 func (b *VMResourceBuilder) Build() string {
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("resource %s \"%s\" {\n", constants.ResourceTypeVirtualMachine, b.name))
+	fmt.Fprintf(&sb, "resource %s \"%s\" {\n", constants.ResourceTypeVirtualMachine, b.name)
 
-	sb.WriteString(fmt.Sprintf("\t%s = \"%s\"\n", constants.FieldCommonName, b.name))
-	sb.WriteString(fmt.Sprintf("\t%s = \"%s\"\n", constants.FieldCommonDescription, b.description))
+	fmt.Fprintf(&sb, "\t%s = \"%s\"\n", constants.FieldCommonName, b.name)
+	fmt.Fprintf(&sb, "\t%s = \"%s\"\n", constants.FieldCommonDescription, b.description)
 
-	sb.WriteString(fmt.Sprintf("\t%s = %d\n", constants.FieldVirtualMachineCPU, b.cpu))
-	sb.WriteString(fmt.Sprintf("\t%s = \"%s\"\n", constants.FieldVirtualMachineMemory, b.memory))
-	sb.WriteString(fmt.Sprintf("\t%s = %s\n", constants.FieldVirtualMachineCPUPinning, strconv.FormatBool(b.cpuPinning)))
-	sb.WriteString(fmt.Sprintf("\t%s = %s\n", constants.FieldVirtualMachineIsolateEmulatorThread, strconv.FormatBool(b.isolateEmulatorThread)))
-	sb.WriteString(fmt.Sprintf("\t%s = \"%s\"\n", constants.FieldVirtualMachineRunStrategy, b.runStrategy))
-	sb.WriteString(fmt.Sprintf("\t%s = \"%s\"\n", constants.FieldVirtualMachineMachineType, b.machineType))
+	fmt.Fprintf(&sb, "\t%s = %d\n", constants.FieldVirtualMachineCPU, b.cpu)
+	fmt.Fprintf(&sb, "\t%s = \"%s\"\n", constants.FieldVirtualMachineMemory, b.memory)
+	fmt.Fprintf(&sb, "\t%s = %s\n", constants.FieldVirtualMachineCPUPinning, strconv.FormatBool(b.cpuPinning))
+	fmt.Fprintf(&sb, "\t%s = %s\n", constants.FieldVirtualMachineIsolateEmulatorThread, strconv.FormatBool(b.isolateEmulatorThread))
+	fmt.Fprintf(&sb, "\t%s = \"%s\"\n", constants.FieldVirtualMachineRunStrategy, b.runStrategy)
+	fmt.Fprintf(&sb, "\t%s = \"%s\"\n", constants.FieldVirtualMachineMachineType, b.machineType)
 
 	if b.networkConfig != nil {
-		sb.WriteString(fmt.Sprintf("\t%s {\n", constants.FieldVirtualMachineNetworkInterface))
-		sb.WriteString(fmt.Sprintf("\t\t%s = \"%s\"\n", constants.FieldNetworkInterfaceName, b.networkConfig.Name))
-		sb.WriteString(fmt.Sprintf("\t\t%s = %d\n", constants.FieldNetworkInterfaceBootOrder, b.networkConfig.BootOrder))
+		fmt.Fprintf(&sb, "\t%s {\n", constants.FieldVirtualMachineNetworkInterface)
+		fmt.Fprintf(&sb, "\t\t%s = \"%s\"\n", constants.FieldNetworkInterfaceName, b.networkConfig.Name)
+		fmt.Fprintf(&sb, "\t\t%s = %d\n", constants.FieldNetworkInterfaceBootOrder, b.networkConfig.BootOrder)
 		sb.WriteString("\t}\n")
 	}
 
 	if b.diskConfig != nil {
-		sb.WriteString(fmt.Sprintf("\t%s {\n", constants.FieldVirtualMachineDisk))
-		sb.WriteString(fmt.Sprintf("\t\t%s = \"%s\"\n", constants.FieldDiskName, b.diskConfig.Name))
-		sb.WriteString(fmt.Sprintf("\t\t%s = \"%s\"\n", constants.FieldDiskType, b.diskConfig.Type))
-		sb.WriteString(fmt.Sprintf("\t\t%s = \"%s\"\n", constants.FieldDiskBus, b.diskConfig.Bus))
-		sb.WriteString(fmt.Sprintf("\t\t%s = %d\n", constants.FieldDiskBootOrder, b.diskConfig.BootOrder))
-		sb.WriteString(fmt.Sprintf("\t\t%s = \"%s\"\n", constants.FieldDiskContainerImageName, b.diskConfig.ContainerImageName))
+		fmt.Fprintf(&sb, "\t%s {\n", constants.FieldVirtualMachineDisk)
+		fmt.Fprintf(&sb, "\t\t%s = \"%s\"\n", constants.FieldDiskName, b.diskConfig.Name)
+		fmt.Fprintf(&sb, "\t\t%s = \"%s\"\n", constants.FieldDiskType, b.diskConfig.Type)
+		fmt.Fprintf(&sb, "\t\t%s = \"%s\"\n", constants.FieldDiskBus, b.diskConfig.Bus)
+		fmt.Fprintf(&sb, "\t\t%s = %d\n", constants.FieldDiskBootOrder, b.diskConfig.BootOrder)
+		fmt.Fprintf(&sb, "\t\t%s = \"%s\"\n", constants.FieldDiskContainerImageName, b.diskConfig.ContainerImageName)
 		sb.WriteString("\t}\n")
 	}
 
 	if b.inputConfig != nil {
-		sb.WriteString(fmt.Sprintf("\t%s {\n", constants.FieldVirtualMachineInput))
-		sb.WriteString(fmt.Sprintf("\t\t%s = \"%s\"\n", constants.FieldInputName, b.inputConfig.Name))
-		sb.WriteString(fmt.Sprintf("\t\t%s = \"%s\"\n", constants.FieldInputType, b.inputConfig.Type))
-		sb.WriteString(fmt.Sprintf("\t\t%s = \"%s\"\n", constants.FieldInputBus, b.inputConfig.Bus))
+		fmt.Fprintf(&sb, "\t%s {\n", constants.FieldVirtualMachineInput)
+		fmt.Fprintf(&sb, "\t\t%s = \"%s\"\n", constants.FieldInputName, b.inputConfig.Name)
+		fmt.Fprintf(&sb, "\t\t%s = \"%s\"\n", constants.FieldInputType, b.inputConfig.Type)
+		fmt.Fprintf(&sb, "\t\t%s = \"%s\"\n", constants.FieldInputBus, b.inputConfig.Bus)
 		sb.WriteString("\t}\n")
 	}
 
@@ -818,7 +818,7 @@ func updateCPUManagerPolicy(ctx context.Context, nodeName string, enableCPUManag
 		},
 	}
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec
 	if err != nil {
 		return fmt.Errorf("failed to send request: %v", err)
 	}

--- a/internal/util/http.go
+++ b/internal/util/http.go
@@ -53,7 +53,7 @@ func DoPost(url, data, cacert string, insecure bool, headers map[string]string) 
 
 	client.Transport = transport
 
-	return client.Do(req)
+	return client.Do(req) //nolint:gosec
 }
 
 func DoGet(url, username, password, token, cacert string, insecure bool) (*http.Response, error) {
@@ -113,5 +113,5 @@ func DoGet(url, username, password, token, cacert string, insecure bool) (*http.
 	// Timings recorded as part of internal metrics
 	log.Println("Time to get req: ", float64((time.Since(start))/time.Millisecond), " ms")
 
-	return client.Do(req)
+	return client.Do(req) //nolint:gosec
 }


### PR DESCRIPTION
- Ignore gosec G704 for HTTP requests against user-defined URLs
- Replace strings.Builder.WriteString(fmt.Sprintf(...)) with fmt.Fprintf(...)
- Ignore gosec G117 for password field in bootstrap request payload

#### Problem:

PRs get spammed with unrelated linter warnings because the code on our `master` branch does not pass the linter.

#### Solution:

Fix the linter warnings.

#### Related Issue(s):

N/A

#### Test plan:

`make validate` should show no issues on from `golangci-lint` or `go fmt`

#### Additional documentation or context

E.g. a CI run where the linter shows warning for parts of the code base that aren't touched by the PR: https://github.com/harvester/terraform-provider-harvester/actions/runs/22633380120/job/65686972727?pr=164