### PR TITLE
feat(vm): add toleration support for virtual machines

### DIFF
--- a/docs/data-sources/virtualmachine.md
+++ b/docs/data-sources/virtualmachine.md
@@ -72,6 +72,7 @@ For example: `sample-tag = sample` adds label `tag.harvesterhci.io/sample-tag: s
 For `ssh-user` tag, the value is added to `cloudinit.user_data` if:
 1. Both `cloudinit.user_data_base64` and `cloudinit.user_data_secret_name` are empty.
 2. There is no `user` field in `cloudinit.user_data`.
+- `toleration` (List of Object) Tolerations allow the VM to be scheduled on nodes with matching taints (see [below for nested schema](#nestedatt--toleration))
 - `tpm` (List of Object) (see [below for nested schema](#nestedatt--tpm))
 
 <a id="nestedatt--cloudinit"></a>
@@ -152,6 +153,18 @@ Read-Only:
 
 - `cpu` (String)
 - `memory` (String)
+
+
+<a id="nestedatt--toleration"></a>
+### Nested Schema for `toleration`
+
+Read-Only:
+
+- `effect` (String)
+- `key` (String)
+- `operator` (String)
+- `toleration_seconds` (Number)
+- `value` (String)
 
 
 <a id="nestedatt--tpm"></a>

--- a/docs/resources/virtualmachine.md
+++ b/docs/resources/virtualmachine.md
@@ -29,6 +29,13 @@ resource "harvester_virtualmachine" "k3os" {
   efi         = true
   secure_boot = false
 
+  toleration {
+    key      = "key1"
+    operator = "Equal"
+    value    = "value1"
+    effect   = "NoSchedule"
+  }
+
   network_interface {
     name         = "nic-1"
     network_name = harvester_network.mgmt-vlan1.id
@@ -226,6 +233,7 @@ For `ssh-user` tag, the value is added to `cloudinit.user_data` if:
 1. Both `cloudinit.user_data_base64` and `cloudinit.user_data_secret_name` are empty.
 2. There is no `user` field in `cloudinit.user_data`.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- `toleration` (Block List) Tolerations allow the VM to be scheduled on nodes with matching taints (see [below for nested schema](#nestedblock--toleration))
 - `tpm` (Block List, Max: 1) (see [below for nested schema](#nestedblock--tpm))
 
 ### Read-Only
@@ -337,6 +345,18 @@ Optional:
 - `delete` (String)
 - `read` (String)
 - `update` (String)
+
+
+<a id="nestedblock--toleration"></a>
+### Nested Schema for `toleration`
+
+Optional:
+
+- `effect` (String) The taint effect to match (empty matches all effects)
+- `key` (String) The taint key that the toleration applies to
+- `operator` (String) The operator (Equal or Exists)
+- `toleration_seconds` (Number) Period of time the toleration tolerates the taint (only for NoExecute)
+- `value` (String) The taint value (only used when operator is Equal)
 
 
 <a id="nestedblock--tpm"></a>

--- a/examples/resources/harvester_virtualmachine/resource.tf
+++ b/examples/resources/harvester_virtualmachine/resource.tf
@@ -14,6 +14,13 @@ resource "harvester_virtualmachine" "k3os" {
   efi         = true
   secure_boot = false
 
+  toleration {
+    key      = "key1"
+    operator = "Equal"
+    value    = "value1"
+    effect   = "NoSchedule"
+  }
+
   network_interface {
     name         = "nic-1"
     network_name = harvester_network.mgmt-vlan1.id

--- a/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
+++ b/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
@@ -460,6 +460,25 @@ func (c *Constructor) Setup() util.Processors {
 				return nil
 			},
 		},
+		{
+			Field: constants.FieldVirtualMachineToleration,
+			Parser: func(i interface{}) error {
+				r := i.(map[string]interface{})
+				toleration := corev1.Toleration{
+					Key:      r[constants.FieldTolerationKey].(string),
+					Operator: corev1.TolerationOperator(r[constants.FieldTolerationOperator].(string)),
+					Value:    r[constants.FieldTolerationValue].(string),
+					Effect:   corev1.TaintEffect(r[constants.FieldTolerationEffect].(string)),
+				}
+				if seconds := r[constants.FieldTolerationTolerationSeconds].(int); seconds != 0 {
+					s := int64(seconds)
+					toleration.TolerationSeconds = &s
+				}
+				vmBuilder.VirtualMachine.Spec.Template.Spec.Tolerations = append(
+					vmBuilder.VirtualMachine.Spec.Template.Spec.Tolerations, toleration)
+				return nil
+			},
+		},
 	}
 	return append(processors, customProcessors...)
 }
@@ -503,6 +522,7 @@ func Updater(c *client.Client, ctx context.Context, vm *kubevirtv1.VirtualMachin
 	vm.Spec.Template.Spec.Domain.Devices.Disks = []kubevirtv1.Disk{}
 	vm.Spec.Template.Spec.Domain.Devices.Inputs = []kubevirtv1.Input{}
 	vm.Spec.Template.Spec.Volumes = []kubevirtv1.Volume{}
+	vm.Spec.Template.Spec.Tolerations = []corev1.Toleration{}
 	vm.Annotations[harvesterutil.AnnotationVolumeClaimTemplates] = "[]"
 	return newVMConstructor(c, ctx, &builder.VMBuilder{
 		VirtualMachine: vm,

--- a/internal/provider/virtualmachine/schema_virtualmachine.go
+++ b/internal/provider/virtualmachine/schema_virtualmachine.go
@@ -200,6 +200,51 @@ please use %s instead of this deprecated field:
 				},
 			},
 		},
+		constants.FieldVirtualMachineToleration: {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Tolerations allow the VM to be scheduled on nodes with matching taints",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					constants.FieldTolerationKey: {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "The taint key that the toleration applies to",
+					},
+					constants.FieldTolerationOperator: {
+						Type:     schema.TypeString,
+						Optional: true,
+						Default:  "Equal",
+						ValidateFunc: validation.StringInSlice([]string{
+							"Equal",
+							"Exists",
+						}, false),
+						Description: "The operator (Equal or Exists)",
+					},
+					constants.FieldTolerationValue: {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "The taint value (only used when operator is Equal)",
+					},
+					constants.FieldTolerationEffect: {
+						Type:     schema.TypeString,
+						Optional: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							"",
+							"NoSchedule",
+							"PreferNoSchedule",
+							"NoExecute",
+						}, false),
+						Description: "The taint effect to match (empty matches all effects)",
+					},
+					constants.FieldTolerationTolerationSeconds: {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Description: "Period of time the toleration tolerates the taint (only for NoExecute)",
+					},
+				},
+			},
+		},
 	}
 	util.NamespacedSchemaWrap(s, false)
 	s[constants.FieldCommonTags].Description = "The tag is reflected as label on the VM.\n" +

--- a/pkg/constants/constants_virtualmachine.go
+++ b/pkg/constants/constants_virtualmachine.go
@@ -29,6 +29,13 @@ const (
 	FieldVirtualMachineNodeSelector          = "node_selector"
 	FieldVirtualMachineCreateInitialSnapshot = "create_initial_snapshot"
 	FieldVirtualMachineHostDevice            = "host_device"
+	FieldVirtualMachineToleration            = "toleration"
+
+	FieldTolerationKey               = "key"
+	FieldTolerationOperator          = "operator"
+	FieldTolerationValue             = "value"
+	FieldTolerationEffect            = "effect"
+	FieldTolerationTolerationSeconds = "toleration_seconds"
 
 	StateVirtualMachineStarting = "Starting"
 	StateVirtualMachineRunning  = "Running"

--- a/pkg/importer/resource_virtualmachine_importer.go
+++ b/pkg/importer/resource_virtualmachine_importer.go
@@ -339,6 +339,25 @@ func (v *VMImporter) Volume() ([]map[string]interface{}, []map[string]interface{
 	return diskStates, cloudInitState, nil
 }
 
+func (v *VMImporter) Tolerations() []map[string]interface{} {
+	tolerations := v.VirtualMachine.Spec.Template.Spec.Tolerations
+	result := make([]map[string]interface{}, 0, len(tolerations))
+	for _, t := range tolerations {
+		tolMap := map[string]interface{}{
+			constants.FieldTolerationKey:               t.Key,
+			constants.FieldTolerationOperator:          string(t.Operator),
+			constants.FieldTolerationValue:             t.Value,
+			constants.FieldTolerationEffect:            string(t.Effect),
+			constants.FieldTolerationTolerationSeconds: 0,
+		}
+		if t.TolerationSeconds != nil {
+			tolMap[constants.FieldTolerationTolerationSeconds] = int(*t.TolerationSeconds)
+		}
+		result = append(result, tolMap)
+	}
+	return result
+}
+
 func (v *VMImporter) NodeName() string {
 	if v.VirtualMachineInstance == nil {
 		return ""
@@ -432,6 +451,7 @@ func ResourceVirtualMachineStateGetter(vm *kubevirtv1.VirtualMachine, vmi *kubev
 			constants.FieldVirtualMachineCPUPinning:            vmImporter.DedicatedCPUPlacement(),
 			constants.FieldVirtualMachineIsolateEmulatorThread: vmImporter.IsolateEmulatorThread(),
 			constants.FieldVirtualMachineNodeSelector:          vm.Spec.Template.Spec.NodeSelector,
+			constants.FieldVirtualMachineToleration:            vmImporter.Tolerations(),
 		},
 	}, nil
 }

--- a/pkg/importer/resource_virtualmachine_importer.go
+++ b/pkg/importer/resource_virtualmachine_importer.go
@@ -339,6 +339,25 @@ func (v *VMImporter) Volume() ([]map[string]interface{}, []map[string]interface{
 	return diskStates, cloudInitState, nil
 }
 
+func (v *VMImporter) Tolerations() []map[string]interface{} {
+	tolerations := v.VirtualMachine.Spec.Template.Spec.Tolerations
+	result := make([]map[string]interface{}, 0, len(tolerations))
+	for _, t := range tolerations {
+		tolMap := map[string]interface{}{
+			constants.FieldTolerationKey:               t.Key,
+			constants.FieldTolerationOperator:          string(t.Operator),
+			constants.FieldTolerationValue:             t.Value,
+			constants.FieldTolerationEffect:            string(t.Effect),
+			constants.FieldTolerationTolerationSeconds: 0,
+		}
+		if t.TolerationSeconds != nil {
+			tolMap[constants.FieldTolerationTolerationSeconds] = int(*t.TolerationSeconds)
+		}
+		result = append(result, tolMap)
+	}
+	return result
+}
+
 func (v *VMImporter) NodeName() string {
 	if v.VirtualMachineInstance == nil {
 		return ""
@@ -435,6 +454,7 @@ func ResourceVirtualMachineStateGetter(vm *kubevirtv1.VirtualMachine, vmi *kubev
 			constants.FieldVirtualMachineCPUPinning:            vmImporter.DedicatedCPUPlacement(),
 			constants.FieldVirtualMachineIsolateEmulatorThread: vmImporter.IsolateEmulatorThread(),
 			constants.FieldVirtualMachineNodeSelector:          vm.Spec.Template.Spec.NodeSelector,
+			constants.FieldVirtualMachineToleration:            vmImporter.Tolerations(),
 		},
 	}, nil
 }

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -405,6 +405,109 @@ func TestNetworkInterface(t *testing.T) {
 	}
 }
 
+func TestTolerations(t *testing.T) {
+	type testcase struct {
+		name        string
+		importer    *VMImporter
+		expectation []map[string]interface{}
+	}
+
+	int64Ptr := func(v int64) *int64 { return &v }
+
+	testcases := []testcase{
+		{
+			name: "nil tolerations returns empty slice",
+			importer: &VMImporter{
+				VirtualMachine: &kubevirtv1.VirtualMachine{
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{},
+						},
+					},
+				},
+			},
+			expectation: []map[string]interface{}{},
+		},
+		{
+			name: "standard toleration",
+			importer: &VMImporter{
+				VirtualMachine: &kubevirtv1.VirtualMachine{
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Tolerations: []corev1.Toleration{
+									{
+										Key:      "key1",
+										Operator: corev1.TolerationOpEqual,
+										Value:    "value1",
+										Effect:   corev1.TaintEffectNoSchedule,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectation: []map[string]interface{}{
+				{
+					constants.FieldTolerationKey:               "key1",
+					constants.FieldTolerationOperator:          "Equal",
+					constants.FieldTolerationValue:             "value1",
+					constants.FieldTolerationEffect:            "NoSchedule",
+					constants.FieldTolerationTolerationSeconds: 0,
+				},
+			},
+		},
+		{
+			name: "Exists operator with TolerationSeconds",
+			importer: &VMImporter{
+				VirtualMachine: &kubevirtv1.VirtualMachine{
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Tolerations: []corev1.Toleration{
+									{
+										Key:               "node.kubernetes.io/not-ready",
+										Operator:          corev1.TolerationOpExists,
+										Effect:            corev1.TaintEffectNoExecute,
+										TolerationSeconds: int64Ptr(300),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectation: []map[string]interface{}{
+				{
+					constants.FieldTolerationKey:               "node.kubernetes.io/not-ready",
+					constants.FieldTolerationOperator:          "Exists",
+					constants.FieldTolerationValue:             "",
+					constants.FieldTolerationEffect:            "NoExecute",
+					constants.FieldTolerationTolerationSeconds: 300,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.importer.Tolerations()
+			if len(result) != len(tc.expectation) {
+				t.Fatalf("expected %d tolerations, got %d", len(tc.expectation), len(result))
+			}
+			for idx, r := range result {
+				e := tc.expectation[idx]
+				for k, ev := range e {
+					if r[k] != ev {
+						t.Errorf("toleration[%d][%s] = %v, expected %v", idx, k, r[k], ev)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestCPU(t *testing.T) {
 	type testcase struct {
 		importer      *VMImporter

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -415,6 +415,109 @@ func TestNetworkInterface(t *testing.T) {
 	}
 }
 
+func TestTolerations(t *testing.T) {
+	type testcase struct {
+		name        string
+		importer    *VMImporter
+		expectation []map[string]interface{}
+	}
+
+	int64Ptr := func(v int64) *int64 { return &v }
+
+	testcases := []testcase{
+		{
+			name: "nil tolerations returns empty slice",
+			importer: &VMImporter{
+				VirtualMachine: &kubevirtv1.VirtualMachine{
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{},
+						},
+					},
+				},
+			},
+			expectation: []map[string]interface{}{},
+		},
+		{
+			name: "standard toleration",
+			importer: &VMImporter{
+				VirtualMachine: &kubevirtv1.VirtualMachine{
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Tolerations: []corev1.Toleration{
+									{
+										Key:      "key1",
+										Operator: corev1.TolerationOpEqual,
+										Value:    "value1",
+										Effect:   corev1.TaintEffectNoSchedule,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectation: []map[string]interface{}{
+				{
+					constants.FieldTolerationKey:               "key1",
+					constants.FieldTolerationOperator:          "Equal",
+					constants.FieldTolerationValue:             "value1",
+					constants.FieldTolerationEffect:            "NoSchedule",
+					constants.FieldTolerationTolerationSeconds: 0,
+				},
+			},
+		},
+		{
+			name: "Exists operator with TolerationSeconds",
+			importer: &VMImporter{
+				VirtualMachine: &kubevirtv1.VirtualMachine{
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Tolerations: []corev1.Toleration{
+									{
+										Key:               "node.kubernetes.io/not-ready",
+										Operator:          corev1.TolerationOpExists,
+										Effect:            corev1.TaintEffectNoExecute,
+										TolerationSeconds: int64Ptr(300),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectation: []map[string]interface{}{
+				{
+					constants.FieldTolerationKey:               "node.kubernetes.io/not-ready",
+					constants.FieldTolerationOperator:          "Exists",
+					constants.FieldTolerationValue:             "",
+					constants.FieldTolerationEffect:            "NoExecute",
+					constants.FieldTolerationTolerationSeconds: 300,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.importer.Tolerations()
+			if len(result) != len(tc.expectation) {
+				t.Fatalf("expected %d tolerations, got %d", len(tc.expectation), len(result))
+			}
+			for idx, r := range result {
+				e := tc.expectation[idx]
+				for k, ev := range e {
+					if r[k] != ev {
+						t.Errorf("toleration[%d][%s] = %v, expected %v", idx, k, r[k], ev)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestCPU(t *testing.T) {
 	type testcase struct {
 		importer      *VMImporter


### PR DESCRIPTION
## Related Issue

harvester/harvester#10140

## Description

Add Kubernetes tolerations support to the `harvester_virtualmachine` resource, allowing VMs to be scheduled on nodes with matching taints.

### Changes

- Add `toleration` block to VM schema with fields: `key`, `operator` (Equal/Exists), `value`, `effect` (NoSchedule/PreferNoSchedule/NoExecute), `toleration_seconds`
- Build `corev1.Toleration` from Terraform state and append to VM spec
- Clear and rebuild tolerations on update to handle additions/removals
- Import tolerations from existing VMs via `Tolerations()` importer method
- Regenerate docs with `make generate`

### Example

```hcl
resource "harvester_virtualmachine" "example" {
  # ...
  toleration {
    key      = "dedicated"
    operator = "Equal"
    value    = "gpu"
    effect   = "NoSchedule"
  }

  toleration {
    key               = "node.kubernetes.io/not-ready"
    operator          = "Exists"
    effect            = "NoExecute"
    toleration_seconds = 300
  }
}
```

## Test plan

- [x] Unit tests: `go test ./pkg/importer/ -run TestTolerations` — pass
- [x] `go build ./...` — compilation passes
- [x] `gofmt -l .` — no formatting issues
- [x] `go generate ./...` — docs generated
- [x] Functional test on Harvester v1.7.1:
  - [x] Created VM with 2 tolerations (`dedicated=gpu:NoSchedule` + `Exists:NoExecute` with toleration_seconds) — verified via `kubectl get vm -o json`
  - [x] Idempotence: `terraform plan` shows 0 changes
  - [x] Update: added 3rd toleration, removed 1st — applied cleanly, no drift
  - [x] `terraform destroy` — VM cleaned up