### PR TITLE
feat(vm): add install_guest_agent to inject qemu-guest-agent via cloud-init

### DIFF
--- a/docs/data-sources/virtualmachine.md
+++ b/docs/data-sources/virtualmachine.md
@@ -49,6 +49,7 @@ data "harvester_virtualmachine" "opensuse154" {
 - `hostname` (String)
 - `id` (String) The ID of this resource.
 - `input` (List of Object) (see [below for nested schema](#nestedatt--input))
+- `install_guest_agent` (Boolean) Install qemu-guest-agent via cloud-init. The agent is injected into cloudinit.user_data when user_data_base64 and user_data_secret_name are not set.
 - `isolate_emulator_thread` (Boolean) To enable isolate emulator thread, ensure that at least one node has the CPU manager enabled, also VM CPU pinning must be enabled. Note that enable option will allocate an additional dedicated CPU.
 - `labels` (Map of String)
 - `machine_type` (String)

--- a/docs/resources/virtualmachine.md
+++ b/docs/resources/virtualmachine.md
@@ -26,6 +26,8 @@ resource "harvester_virtualmachine" "k3os" {
   cpu    = 4
   memory = "4Gi"
 
+  install_guest_agent = true
+
   efi         = true
   secure_boot = false
 
@@ -205,6 +207,7 @@ resource "harvester_virtualmachine" "opensuse154" {
 - `host_device` (Block List) Attaches a host device to the VM (see [below for nested schema](#nestedblock--host_device))
 - `hostname` (String)
 - `input` (Block List) (see [below for nested schema](#nestedblock--input))
+- `install_guest_agent` (Boolean) Install qemu-guest-agent via cloud-init. The agent is injected into cloudinit.user_data when user_data_base64 and user_data_secret_name are not set.
 - `isolate_emulator_thread` (Boolean) To enable isolate emulator thread, ensure that at least one node has the CPU manager enabled, also VM CPU pinning must be enabled. Note that enable option will allocate an additional dedicated CPU.
 - `labels` (Map of String)
 - `machine_type` (String)

--- a/examples/resources/harvester_virtualmachine/resource.tf
+++ b/examples/resources/harvester_virtualmachine/resource.tf
@@ -11,6 +11,8 @@ resource "harvester_virtualmachine" "k3os" {
   cpu    = 4
   memory = "4Gi"
 
+  install_guest_agent = true
+
   efi         = true
   secure_boot = false
 

--- a/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
+++ b/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
@@ -23,6 +23,8 @@ import (
 
 const (
 	vmCreator = "terraform-provider-harvester"
+
+	guestAgentSnippet = "package_update: true\npackages:\n  - qemu-guest-agent\nruncmd:\n  - - systemctl\n    - enable\n    - '--now'\n    - qemu-ga"
 )
 
 var (
@@ -33,7 +35,8 @@ type Constructor struct {
 	Client  *client.Client
 	Context context.Context
 
-	Builder *builder.VMBuilder
+	Builder           *builder.VMBuilder
+	InstallGuestAgent bool
 }
 
 func (c *Constructor) Setup() util.Processors {
@@ -334,6 +337,14 @@ func (c *Constructor) Setup() util.Processors {
 			Required: true,
 		},
 		{
+			Field: constants.FieldVirtualMachineInstallGuestAgent,
+			Parser: func(i interface{}) error {
+				c.InstallGuestAgent = i.(bool)
+				return nil
+			},
+			Required: true,
+		},
+		{
 			Field: constants.FieldVirtualMachineCloudInit,
 			Parser: func(i interface{}) error {
 				r := i.(map[string]interface{})
@@ -398,6 +409,15 @@ func (c *Constructor) Setup() util.Processors {
 							cloudInitSource.UserData = fmt.Sprintf("#cloud-config\nssh_authorized_keys:\n  - %s", strings.Join(publicKeys, "\n  - "))
 						} else {
 							cloudInitSource.UserData += fmt.Sprintf("\nssh_authorized_keys:\n  - %s", strings.Join(publicKeys, "\n  - "))
+						}
+					}
+				}
+				if c.InstallGuestAgent && cloudInitSource.UserDataBase64 == "" && cloudInitSource.UserDataSecretName == "" {
+					if !strings.Contains(cloudInitSource.UserData, "qemu-guest-agent") {
+						if cloudInitSource.UserData == "" {
+							cloudInitSource.UserData = "#cloud-config\n" + guestAgentSnippet
+						} else {
+							cloudInitSource.UserData += "\n" + guestAgentSnippet
 						}
 					}
 				}

--- a/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
+++ b/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
@@ -23,8 +23,6 @@ import (
 
 const (
 	vmCreator = "terraform-provider-harvester"
-
-	guestAgentSnippet = "package_update: true\npackages:\n  - qemu-guest-agent\nruncmd:\n  - - systemctl\n    - enable\n    - '--now'\n    - qemu-ga"
 )
 
 var (
@@ -415,9 +413,9 @@ func (c *Constructor) Setup() util.Processors {
 				if c.InstallGuestAgent && cloudInitSource.UserDataBase64 == "" && cloudInitSource.UserDataSecretName == "" {
 					if !strings.Contains(cloudInitSource.UserData, "qemu-guest-agent") {
 						if cloudInitSource.UserData == "" {
-							cloudInitSource.UserData = "#cloud-config\n" + guestAgentSnippet
+							cloudInitSource.UserData = "#cloud-config\n" + constants.GuestAgentCloudInitSnippet
 						} else {
-							cloudInitSource.UserData += "\n" + guestAgentSnippet
+							cloudInitSource.UserData += "\n" + constants.GuestAgentCloudInitSnippet
 						}
 					}
 				}

--- a/internal/provider/virtualmachine/schema_virtualmachine.go
+++ b/internal/provider/virtualmachine/schema_virtualmachine.go
@@ -200,6 +200,12 @@ please use %s instead of this deprecated field:
 				},
 			},
 		},
+		constants.FieldVirtualMachineInstallGuestAgent: {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Install qemu-guest-agent via cloud-init. The agent is injected into cloudinit.user_data when user_data_base64 and user_data_secret_name are not set.",
+		},
 	}
 	util.NamespacedSchemaWrap(s, false)
 	s[constants.FieldCommonTags].Description = "The tag is reflected as label on the VM.\n" +

--- a/pkg/constants/constants_virtualmachine.go
+++ b/pkg/constants/constants_virtualmachine.go
@@ -42,6 +42,11 @@ const (
 	SubresourceRestart     = "restart"
 )
 
+// GuestAgentCloudInitSnippet is appended to cloudinit.user_data when
+// install_guest_agent is enabled. It is also used to strip the injection back
+// out on read so the user_data field stays idempotent.
+const GuestAgentCloudInitSnippet = "package_update: true\npackages:\n  - qemu-guest-agent\nruncmd:\n  - - systemctl\n    - enable\n    - '--now'\n    - qemu-ga"
+
 const (
 	FieldCloudInitType                  = "type"
 	FieldCloudInitNetworkData           = "network_data"

--- a/pkg/constants/constants_virtualmachine.go
+++ b/pkg/constants/constants_virtualmachine.go
@@ -29,6 +29,7 @@ const (
 	FieldVirtualMachineNodeSelector          = "node_selector"
 	FieldVirtualMachineCreateInitialSnapshot = "create_initial_snapshot"
 	FieldVirtualMachineHostDevice            = "host_device"
+	FieldVirtualMachineInstallGuestAgent     = "install_guest_agent"
 
 	StateVirtualMachineStarting = "Starting"
 	StateVirtualMachineRunning  = "Running"

--- a/pkg/importer/resource_virtualmachine_importer.go
+++ b/pkg/importer/resource_virtualmachine_importer.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
@@ -339,6 +340,21 @@ func (v *VMImporter) Volume() ([]map[string]interface{}, []map[string]interface{
 	return diskStates, cloudInitState, nil
 }
 
+func (v *VMImporter) InstallGuestAgent() bool {
+	for _, volume := range v.VirtualMachine.Spec.Template.Spec.Volumes {
+		var userData string
+		if volume.CloudInitNoCloud != nil {
+			userData = volume.CloudInitNoCloud.UserData
+		} else if volume.CloudInitConfigDrive != nil {
+			userData = volume.CloudInitConfigDrive.UserData
+		}
+		if userData != "" && strings.Contains(userData, "qemu-guest-agent") {
+			return true
+		}
+	}
+	return false
+}
+
 func (v *VMImporter) NodeName() string {
 	if v.VirtualMachineInstance == nil {
 		return ""
@@ -432,6 +448,7 @@ func ResourceVirtualMachineStateGetter(vm *kubevirtv1.VirtualMachine, vmi *kubev
 			constants.FieldVirtualMachineCPUPinning:            vmImporter.DedicatedCPUPlacement(),
 			constants.FieldVirtualMachineIsolateEmulatorThread: vmImporter.IsolateEmulatorThread(),
 			constants.FieldVirtualMachineNodeSelector:          vm.Spec.Template.Spec.NodeSelector,
+			constants.FieldVirtualMachineInstallGuestAgent:     vmImporter.InstallGuestAgent(),
 		},
 	}, nil
 }

--- a/pkg/importer/resource_virtualmachine_importer.go
+++ b/pkg/importer/resource_virtualmachine_importer.go
@@ -251,12 +251,26 @@ func (v *VMImporter) pvcVolume(volume kubevirtv1.Volume, state map[string]interf
 	return nil
 }
 
+// stripGuestAgentSnippet reverses the install_guest_agent injection so the
+// user_data field remains idempotent across reads. The snippet is either set as
+// the whole user_data (when the configured user_data was empty) or appended with
+// a leading newline to the configured user_data.
+func stripGuestAgentSnippet(userData string) string {
+	if userData == "#cloud-config\n"+constants.GuestAgentCloudInitSnippet {
+		return ""
+	}
+	if suffix := "\n" + constants.GuestAgentCloudInitSnippet; strings.HasSuffix(userData, suffix) {
+		return strings.TrimSuffix(userData, suffix)
+	}
+	return userData
+}
+
 func (v *VMImporter) cloudInit(volume kubevirtv1.Volume) []map[string]interface{} {
 	var cloudInitState = make([]map[string]interface{}, 0, 1)
 	if volume.CloudInitNoCloud != nil {
 		cloudInitState = append(cloudInitState, map[string]interface{}{
 			constants.FieldCloudInitType:              builder.CloudInitTypeNoCloud,
-			constants.FieldCloudInitUserData:          volume.CloudInitNoCloud.UserData,
+			constants.FieldCloudInitUserData:          stripGuestAgentSnippet(volume.CloudInitNoCloud.UserData),
 			constants.FieldCloudInitUserDataBase64:    volume.CloudInitNoCloud.UserDataBase64,
 			constants.FieldCloudInitNetworkData:       volume.CloudInitNoCloud.NetworkData,
 			constants.FieldCloudInitNetworkDataBase64: volume.CloudInitNoCloud.NetworkDataBase64,
@@ -270,7 +284,7 @@ func (v *VMImporter) cloudInit(volume kubevirtv1.Volume) []map[string]interface{
 	} else if volume.CloudInitConfigDrive != nil {
 		cloudInitState = append(cloudInitState, map[string]interface{}{
 			constants.FieldCloudInitType:              builder.CloudInitTypeConfigDrive,
-			constants.FieldCloudInitUserData:          volume.CloudInitConfigDrive.UserData,
+			constants.FieldCloudInitUserData:          stripGuestAgentSnippet(volume.CloudInitConfigDrive.UserData),
 			constants.FieldCloudInitUserDataBase64:    volume.CloudInitConfigDrive.UserDataBase64,
 			constants.FieldCloudInitNetworkData:       volume.CloudInitConfigDrive.NetworkData,
 			constants.FieldCloudInitNetworkDataBase64: volume.CloudInitConfigDrive.NetworkDataBase64,

--- a/pkg/importer/resource_virtualmachine_importer.go
+++ b/pkg/importer/resource_virtualmachine_importer.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
@@ -339,6 +340,21 @@ func (v *VMImporter) Volume() ([]map[string]interface{}, []map[string]interface{
 	return diskStates, cloudInitState, nil
 }
 
+func (v *VMImporter) InstallGuestAgent() bool {
+	for _, volume := range v.VirtualMachine.Spec.Template.Spec.Volumes {
+		var userData string
+		if volume.CloudInitNoCloud != nil {
+			userData = volume.CloudInitNoCloud.UserData
+		} else if volume.CloudInitConfigDrive != nil {
+			userData = volume.CloudInitConfigDrive.UserData
+		}
+		if userData != "" && strings.Contains(userData, "qemu-guest-agent") {
+			return true
+		}
+	}
+	return false
+}
+
 func (v *VMImporter) NodeName() string {
 	if v.VirtualMachineInstance == nil {
 		return ""
@@ -435,6 +451,7 @@ func ResourceVirtualMachineStateGetter(vm *kubevirtv1.VirtualMachine, vmi *kubev
 			constants.FieldVirtualMachineCPUPinning:            vmImporter.DedicatedCPUPlacement(),
 			constants.FieldVirtualMachineIsolateEmulatorThread: vmImporter.IsolateEmulatorThread(),
 			constants.FieldVirtualMachineNodeSelector:          vm.Spec.Template.Spec.NodeSelector,
+			constants.FieldVirtualMachineInstallGuestAgent:     vmImporter.InstallGuestAgent(),
 		},
 	}, nil
 }

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -405,6 +405,111 @@ func TestNetworkInterface(t *testing.T) {
 	}
 }
 
+func TestInstallGuestAgent(t *testing.T) {
+	type testcase struct {
+		name     string
+		importer *VMImporter
+		expected bool
+	}
+
+	testcases := []testcase{
+		{
+			name: "no cloud-init volumes returns false",
+			importer: &VMImporter{
+				VirtualMachine: &kubevirtv1.VirtualMachine{
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "cloud-init with guest agent snippet returns true",
+			importer: &VMImporter{
+				VirtualMachine: &kubevirtv1.VirtualMachine{
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Volumes: []kubevirtv1.Volume{
+									{
+										Name: "cloudinitdisk",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+												UserData: "#cloud-config\npackage_update: true\npackages:\n  - qemu-guest-agent\nruncmd:\n  - - systemctl\n    - enable\n    - '--now'\n    - qemu-ga",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "cloud-init without guest agent returns false",
+			importer: &VMImporter{
+				VirtualMachine: &kubevirtv1.VirtualMachine{
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Volumes: []kubevirtv1.Volume{
+									{
+										Name: "cloudinitdisk",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+												UserData: "#cloud-config\nuser: sles\n",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "base64 user data returns false",
+			importer: &VMImporter{
+				VirtualMachine: &kubevirtv1.VirtualMachine{
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Volumes: []kubevirtv1.Volume{
+									{
+										Name: "cloudinitdisk",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+												UserDataBase64: "I2Nsb3VkLWNvbmZpZwpwYWNrYWdlczoKICAtIHFlbXUtZ3Vlc3QtYWdlbnQ=",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.importer.InstallGuestAgent()
+			if result != tc.expected {
+				t.Errorf("InstallGuestAgent() = %v, expected %v", result, tc.expected)
+			}
+		})
+	}
+}
+
 func TestCPU(t *testing.T) {
 	type testcase struct {
 		importer      *VMImporter

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -670,3 +670,38 @@ func TestResourceRequestsImport(t *testing.T) {
 		t.Errorf("Requests() nil memory = %q, want empty", got)
 	}
 }
+
+func TestStripGuestAgentSnippet(t *testing.T) {
+	snippet := constants.GuestAgentCloudInitSnippet
+	testcases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no injection is left untouched",
+			input:    "#cloud-config\npackages:\n  - vim\n",
+			expected: "#cloud-config\npackages:\n  - vim\n",
+		},
+		{
+			name:     "injection appended to existing user_data is removed",
+			input:    "#cloud-config\npackages:\n  - vim\n\n" + snippet,
+			expected: "#cloud-config\npackages:\n  - vim\n",
+		},
+		{
+			name:     "injection into empty user_data returns empty",
+			input:    "#cloud-config\n" + snippet,
+			expected: "",
+		},
+		{
+			name:     "empty user_data stays empty",
+			input:    "",
+			expected: "",
+		},
+	}
+	for _, tc := range testcases {
+		if got := stripGuestAgentSnippet(tc.input); got != tc.expected {
+			t.Errorf("%s: stripGuestAgentSnippet(%q) = %q, want %q", tc.name, tc.input, got, tc.expected)
+		}
+	}
+}

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -680,3 +680,38 @@ func TestResourceRequestsImport(t *testing.T) {
 		t.Errorf("Requests() nil memory = %q, want empty", got)
 	}
 }
+
+func TestStripGuestAgentSnippet(t *testing.T) {
+	snippet := constants.GuestAgentCloudInitSnippet
+	testcases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no injection is left untouched",
+			input:    "#cloud-config\npackages:\n  - vim\n",
+			expected: "#cloud-config\npackages:\n  - vim\n",
+		},
+		{
+			name:     "injection appended to existing user_data is removed",
+			input:    "#cloud-config\npackages:\n  - vim\n\n" + snippet,
+			expected: "#cloud-config\npackages:\n  - vim\n",
+		},
+		{
+			name:     "injection into empty user_data returns empty",
+			input:    "#cloud-config\n" + snippet,
+			expected: "",
+		},
+		{
+			name:     "empty user_data stays empty",
+			input:    "",
+			expected: "",
+		},
+	}
+	for _, tc := range testcases {
+		if got := stripGuestAgentSnippet(tc.input); got != tc.expected {
+			t.Errorf("%s: stripGuestAgentSnippet(%q) = %q, want %q", tc.name, tc.input, got, tc.expected)
+		}
+	}
+}

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -415,6 +415,111 @@ func TestNetworkInterface(t *testing.T) {
 	}
 }
 
+func TestInstallGuestAgent(t *testing.T) {
+	type testcase struct {
+		name     string
+		importer *VMImporter
+		expected bool
+	}
+
+	testcases := []testcase{
+		{
+			name: "no cloud-init volumes returns false",
+			importer: &VMImporter{
+				VirtualMachine: &kubevirtv1.VirtualMachine{
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "cloud-init with guest agent snippet returns true",
+			importer: &VMImporter{
+				VirtualMachine: &kubevirtv1.VirtualMachine{
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Volumes: []kubevirtv1.Volume{
+									{
+										Name: "cloudinitdisk",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+												UserData: "#cloud-config\npackage_update: true\npackages:\n  - qemu-guest-agent\nruncmd:\n  - - systemctl\n    - enable\n    - '--now'\n    - qemu-ga",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "cloud-init without guest agent returns false",
+			importer: &VMImporter{
+				VirtualMachine: &kubevirtv1.VirtualMachine{
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Volumes: []kubevirtv1.Volume{
+									{
+										Name: "cloudinitdisk",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+												UserData: "#cloud-config\nuser: sles\n",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "base64 user data returns false",
+			importer: &VMImporter{
+				VirtualMachine: &kubevirtv1.VirtualMachine{
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Volumes: []kubevirtv1.Volume{
+									{
+										Name: "cloudinitdisk",
+										VolumeSource: kubevirtv1.VolumeSource{
+											CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+												UserDataBase64: "I2Nsb3VkLWNvbmZpZwpwYWNrYWdlczoKICAtIHFlbXUtZ3Vlc3QtYWdlbnQ=",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.importer.InstallGuestAgent()
+			if result != tc.expected {
+				t.Errorf("InstallGuestAgent() = %v, expected %v", result, tc.expected)
+			}
+		})
+	}
+}
+
 func TestCPU(t *testing.T) {
 	type testcase struct {
 		importer      *VMImporter


### PR DESCRIPTION
## Related Issue

harvester/harvester#10141

## Description

Add `install_guest_agent` boolean field to the `harvester_virtualmachine` resource that injects the qemu-guest-agent package and service enablement into cloud-init `user_data`, matching the Harvester UI "Install Guest Agent" checkbox behavior.

### Changes

- Add `install_guest_agent` schema field (bool, default `false`)
- Add `InstallGuestAgent` field to Constructor, processed before CloudInit
- Inject cloud-init snippet (`package_update`, `packages`, `runcmd`) into `user_data` when:
  - `install_guest_agent = true`
  - `user_data_base64` and `user_data_secret_name` are not set
  - `qemu-guest-agent` is not already present in `user_data`
- Import by detecting `qemu-guest-agent` in cloud-init volume UserData
- Regenerate docs with `make generate`

### Example

```hcl
resource "harvester_virtualmachine" "example" {
  # ...
  install_guest_agent = true

  cloudinit {
    user_data = "#cloud-config\nuser: sles\n"
  }
}
```

The guest agent snippet is appended to the existing `user_data`.

## Test plan

- [x] Unit tests: `go test ./pkg/importer/ -run TestInstallGuestAgent` — pass
- [x] `go build ./...` — compilation passes
- [x] `gofmt -l .` — no formatting issues
- [x] `go generate ./...` — docs generated
- [x] Functional test on Harvester v1.7.1:
  - [x] Created VM with `install_guest_agent = true` — verified cloud-init user_data contains `qemu-guest-agent` package and `systemctl enable --now qemu-guest-agent` runcmd
  - [x] Idempotence: `terraform plan` shows 0 changes
  - [x] Toggle to `install_guest_agent = false` — cloud-init snippet removed
  - [x] `terraform destroy` — VM cleaned up