### PR TITLE
feat(vm): add access_credentials, configmap/secret disks, and DNS options

### DIFF
--- a/docs/data-sources/virtualmachine.md
+++ b/docs/data-sources/virtualmachine.md
@@ -37,6 +37,7 @@ data "harvester_virtualmachine" "opensuse154" {
 
 ### Read-Only
 
+- `access_credentials` (List of Object) Access credentials for the VM (SSH public keys or user passwords) (see [below for nested schema](#nestedatt--access_credentials))
 - `cloudinit` (List of Object) (see [below for nested schema](#nestedatt--cloudinit))
 - `cpu` (Number)
 - `cpu_model` (String) CPU model for the virtual machine
@@ -44,6 +45,8 @@ data "harvester_virtualmachine" "opensuse154" {
 - `create_initial_snapshot` (Boolean) Create an initial snapshot named {vm-name}-initial after the VM is created and ready
 - `description` (String) Any text you want that better describes this resource
 - `disk` (List of Object) (see [below for nested schema](#nestedatt--disk))
+- `dns_config` (List of Object) DNS configuration for the VM pod (see [below for nested schema](#nestedatt--dns_config))
+- `dns_policy` (String) DNS policy for the VM pod: ClusterFirst, ClusterFirstWithHostNet, Default, or None
 - `efi` (Boolean)
 - `host_device` (List of Object) Attaches a host device to the VM (see [below for nested schema](#nestedatt--host_device))
 - `hostname` (String)
@@ -74,6 +77,33 @@ For `ssh-user` tag, the value is added to `cloudinit.user_data` if:
 2. There is no `user` field in `cloudinit.user_data`.
 - `tpm` (List of Object) (see [below for nested schema](#nestedatt--tpm))
 
+<a id="nestedatt--access_credentials"></a>
+### Nested Schema for `access_credentials`
+
+Read-Only:
+
+- `ssh_public_key` (List of Object) (see [below for nested schema](#nestedobjatt--access_credentials--ssh_public_key))
+- `user_password` (List of Object) (see [below for nested schema](#nestedobjatt--access_credentials--user_password))
+
+<a id="nestedobjatt--access_credentials--ssh_public_key"></a>
+### Nested Schema for `access_credentials.ssh_public_key`
+
+Read-Only:
+
+- `propagation_method` (String)
+- `secret_name` (String)
+- `users` (List of String)
+
+
+<a id="nestedobjatt--access_credentials--user_password"></a>
+### Nested Schema for `access_credentials.user_password`
+
+Read-Only:
+
+- `secret_name` (String)
+
+
+
 <a id="nestedatt--cloudinit"></a>
 ### Nested Schema for `cloudinit`
 
@@ -98,16 +128,37 @@ Read-Only:
 - `boot_order` (Number)
 - `bus` (String)
 - `cache_mode` (String)
+- `configmap_name` (String)
 - `container_image_name` (String)
 - `existing_volume_name` (String)
 - `hot_plug` (Boolean)
 - `image` (String)
 - `name` (String)
+- `secret_name` (String)
 - `size` (String)
 - `storage_class_name` (String)
 - `type` (String)
 - `volume_mode` (String)
 - `volume_name` (String)
+
+
+<a id="nestedatt--dns_config"></a>
+### Nested Schema for `dns_config`
+
+Read-Only:
+
+- `nameservers` (List of String)
+- `options` (List of Object) (see [below for nested schema](#nestedobjatt--dns_config--options))
+- `searches` (List of String)
+
+<a id="nestedobjatt--dns_config--options"></a>
+### Nested Schema for `dns_config.options`
+
+Read-Only:
+
+- `name` (String)
+- `value` (String)
+
 
 
 <a id="nestedatt--host_device"></a>

--- a/docs/resources/virtualmachine.md
+++ b/docs/resources/virtualmachine.md
@@ -195,12 +195,15 @@ resource "harvester_virtualmachine" "opensuse154" {
 
 ### Optional
 
+- `access_credentials` (Block List) Access credentials for the VM (SSH public keys or user passwords) (see [below for nested schema](#nestedblock--access_credentials))
 - `cloudinit` (Block List, Max: 1) (see [below for nested schema](#nestedblock--cloudinit))
 - `cpu` (Number)
 - `cpu_model` (String) CPU model for the virtual machine
 - `cpu_pinning` (Boolean) To enable VM CPU pinning, ensure that at least one node has the CPU manager enabled
 - `create_initial_snapshot` (Boolean) Create an initial snapshot named {vm-name}-initial after the VM is created and ready
 - `description` (String) Any text you want that better describes this resource
+- `dns_config` (Block List, Max: 1) DNS configuration for the VM pod (see [below for nested schema](#nestedblock--dns_config))
+- `dns_policy` (String) DNS policy for the VM pod: ClusterFirst, ClusterFirstWithHostNet, Default, or None
 - `efi` (Boolean)
 - `host_device` (Block List) Attaches a host device to the VM (see [below for nested schema](#nestedblock--host_device))
 - `hostname` (String)
@@ -249,10 +252,12 @@ Optional:
 - `boot_order` (Number)
 - `bus` (String)
 - `cache_mode` (String)
+- `configmap_name` (String) Name of a ConfigMap to mount as a disk volume
 - `container_image_name` (String)
 - `existing_volume_name` (String)
 - `hot_plug` (Boolean)
 - `image` (String)
+- `secret_name` (String) Name of a Secret to mount as a disk volume
 - `size` (String)
 - `storage_class_name` (String)
 - `type` (String)
@@ -282,6 +287,36 @@ Read-Only:
 - `ip_address` (String)
 
 
+<a id="nestedblock--access_credentials"></a>
+### Nested Schema for `access_credentials`
+
+Optional:
+
+- `ssh_public_key` (Block List, Max: 1) SSH public key access credential sourced from a Kubernetes secret (see [below for nested schema](#nestedblock--access_credentials--ssh_public_key))
+- `user_password` (Block List, Max: 1) User password access credential sourced from a Kubernetes secret, propagated via qemu guest agent (see [below for nested schema](#nestedblock--access_credentials--user_password))
+
+<a id="nestedblock--access_credentials--ssh_public_key"></a>
+### Nested Schema for `access_credentials.ssh_public_key`
+
+Required:
+
+- `propagation_method` (String) Method to propagate SSH keys: configDrive, noCloud, or qemuGuestAgent
+- `secret_name` (String) Name of the Kubernetes secret containing SSH public keys
+
+Optional:
+
+- `users` (List of String) List of guest users for qemuGuestAgent propagation (required when propagation_method is qemuGuestAgent)
+
+
+<a id="nestedblock--access_credentials--user_password"></a>
+### Nested Schema for `access_credentials.user_password`
+
+Required:
+
+- `secret_name` (String) Name of the Kubernetes secret containing user passwords
+
+
+
 <a id="nestedblock--cloudinit"></a>
 ### Nested Schema for `cloudinit`
 
@@ -294,6 +329,28 @@ Optional:
 - `user_data` (String)
 - `user_data_base64` (String)
 - `user_data_secret_name` (String)
+
+
+<a id="nestedblock--dns_config"></a>
+### Nested Schema for `dns_config`
+
+Optional:
+
+- `nameservers` (List of String) List of DNS nameservers
+- `options` (Block List) List of DNS resolver options (see [below for nested schema](#nestedblock--dns_config--options))
+- `searches` (List of String) List of DNS search domains
+
+<a id="nestedblock--dns_config--options"></a>
+### Nested Schema for `dns_config.options`
+
+Required:
+
+- `name` (String) DNS option name
+
+Optional:
+
+- `value` (String) DNS option value
+
 
 
 <a id="nestedblock--host_device"></a>

--- a/examples/resources/harvester_virtualmachine/access_credentials.tf
+++ b/examples/resources/harvester_virtualmachine/access_credentials.tf
@@ -1,0 +1,81 @@
+# VM with SSH access credentials propagated via cloud-init
+resource "harvester_virtualmachine" "ssh_access" {
+  name      = "ssh-access-vm"
+  namespace = "default"
+
+  description = "VM with SSH key injection via access credentials"
+
+  cpu    = 2
+  memory = "4Gi"
+
+  run_strategy = "RerunOnFailure"
+  machine_type = "q35"
+
+  # Inject SSH keys from a Kubernetes secret
+  access_credentials {
+    ssh_public_key {
+      secret_name        = kubernetes_secret.ssh_keys.metadata[0].name
+      propagation_method = "noCloud"
+    }
+  }
+
+  network_interface {
+    name = "nic-1"
+  }
+
+  disk {
+    name       = "rootdisk"
+    type       = "disk"
+    size       = "20Gi"
+    bus        = "virtio"
+    boot_order = 1
+    image      = "default/ubuntu-24.04"
+  }
+}
+
+# VM with SSH keys injected via qemu guest agent (runtime update)
+resource "harvester_virtualmachine" "guest_agent_ssh" {
+  name      = "guest-agent-ssh-vm"
+  namespace = "default"
+
+  description = "VM with SSH keys updated at runtime via guest agent"
+
+  cpu    = 2
+  memory = "4Gi"
+
+  run_strategy = "RerunOnFailure"
+  machine_type = "q35"
+
+  access_credentials {
+    ssh_public_key {
+      secret_name        = kubernetes_secret.ssh_keys.metadata[0].name
+      propagation_method = "qemuGuestAgent"
+      users              = ["root", "admin"]
+    }
+  }
+
+  network_interface {
+    name = "nic-1"
+  }
+
+  disk {
+    name       = "rootdisk"
+    type       = "disk"
+    size       = "20Gi"
+    bus        = "virtio"
+    boot_order = 1
+    image      = "default/ubuntu-24.04"
+  }
+}
+
+# Kubernetes secret containing SSH public keys
+resource "kubernetes_secret" "ssh_keys" {
+  metadata {
+    name      = "my-ssh-keys"
+    namespace = "default"
+  }
+
+  data = {
+    "admin-key" = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5... admin@example.com"
+  }
+}

--- a/examples/resources/harvester_virtualmachine/configmap_secret_disk.tf
+++ b/examples/resources/harvester_virtualmachine/configmap_secret_disk.tf
@@ -1,0 +1,81 @@
+# VM with a ConfigMap mounted as a disk (application config injection)
+resource "harvester_virtualmachine" "with_config" {
+  name      = "app-with-config"
+  namespace = "default"
+
+  description = "VM with application config injected via ConfigMap disk"
+
+  cpu    = 2
+  memory = "4Gi"
+
+  run_strategy = "RerunOnFailure"
+  machine_type = "q35"
+
+  network_interface {
+    name = "nic-1"
+  }
+
+  disk {
+    name       = "rootdisk"
+    type       = "disk"
+    size       = "20Gi"
+    bus        = "virtio"
+    boot_order = 1
+    image      = "default/ubuntu-24.04"
+  }
+
+  # ConfigMap mounted as a read-only disk inside the VM
+  disk {
+    name           = "config-disk"
+    type           = "disk"
+    bus            = "virtio"
+    configmap_name = kubernetes_config_map.app_config.metadata[0].name
+  }
+}
+
+# VM with a Secret mounted as a disk (certificates, credentials)
+resource "harvester_virtualmachine" "with_secret_disk" {
+  name      = "app-with-certs"
+  namespace = "default"
+
+  description = "VM with TLS certificates injected via Secret disk"
+
+  cpu    = 2
+  memory = "4Gi"
+
+  run_strategy = "RerunOnFailure"
+  machine_type = "q35"
+
+  network_interface {
+    name = "nic-1"
+  }
+
+  disk {
+    name       = "rootdisk"
+    type       = "disk"
+    size       = "20Gi"
+    bus        = "virtio"
+    boot_order = 1
+    image      = "default/ubuntu-24.04"
+  }
+
+  # Secret mounted as a read-only disk inside the VM
+  disk {
+    name        = "certs-disk"
+    type        = "disk"
+    bus         = "virtio"
+    secret_name = "tls-certificates"
+  }
+}
+
+resource "kubernetes_config_map" "app_config" {
+  metadata {
+    name      = "app-config"
+    namespace = "default"
+  }
+
+  data = {
+    "app.conf" = "listen_port=8080\nlog_level=info"
+    "db.conf"  = "host=db.internal\nport=5432"
+  }
+}

--- a/examples/resources/harvester_virtualmachine/dns_config.tf
+++ b/examples/resources/harvester_virtualmachine/dns_config.tf
@@ -1,0 +1,42 @@
+# VM with custom DNS configuration
+resource "harvester_virtualmachine" "custom_dns" {
+  name      = "custom-dns-vm"
+  namespace = "default"
+
+  description = "VM with custom DNS policy and configuration"
+
+  cpu    = 2
+  memory = "4Gi"
+
+  run_strategy = "RerunOnFailure"
+  machine_type = "q35"
+
+  # Override cluster DNS with custom nameservers
+  dns_policy = "None"
+
+  dns_config {
+    nameservers = ["8.8.8.8", "8.8.4.4"]
+    searches    = ["example.com", "internal.local"]
+
+    options {
+      name  = "ndots"
+      value = "5"
+    }
+    options {
+      name = "single-request-reopen"
+    }
+  }
+
+  network_interface {
+    name = "nic-1"
+  }
+
+  disk {
+    name       = "rootdisk"
+    type       = "disk"
+    size       = "20Gi"
+    bus        = "virtio"
+    boot_order = 1
+    image      = "default/ubuntu-24.04"
+  }
+}

--- a/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
+++ b/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
@@ -242,6 +242,8 @@ func (c *Constructor) Setup() util.Processors {
 				volumeName := r[constants.FieldDiskVolumeName].(string)
 				existingVolumeName := r[constants.FieldDiskExistingVolumeName].(string)
 				containerImageName := r[constants.FieldDiskContainerImageName].(string)
+				configMapName := r[constants.FieldDiskConfigMapName].(string)
+				secretName := r[constants.FieldDiskSecretName].(string)
 				hotPlug := r[constants.FieldDiskHotPlug].(bool)
 				isCDRom := diskType == builder.DiskTypeCDRom
 				if diskBus == "" {
@@ -263,7 +265,25 @@ func (c *Constructor) Setup() util.Processors {
 					}
 				}
 
-				if existingVolumeName != "" {
+				if configMapName != "" {
+					vmBuilder.Volume(diskName, kubevirtv1.Volume{
+						Name: diskName,
+						VolumeSource: kubevirtv1.VolumeSource{
+							ConfigMap: &kubevirtv1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{Name: configMapName},
+							},
+						},
+					})
+				} else if secretName != "" {
+					vmBuilder.Volume(diskName, kubevirtv1.Volume{
+						Name: diskName,
+						VolumeSource: kubevirtv1.VolumeSource{
+							Secret: &kubevirtv1.SecretVolumeSource{
+								SecretName: secretName,
+							},
+						},
+					})
+				} else if existingVolumeName != "" {
 					vmBuilder.ExistingPVCVolume(diskName, existingVolumeName, hotPlug)
 				} else if containerImageName != "" {
 					vmBuilder.ContainerDiskVolume(diskName, containerImageName, builder.DefaultImagePullPolicy)
@@ -460,6 +480,36 @@ func (c *Constructor) Setup() util.Processors {
 				return nil
 			},
 		},
+		{
+			Field: constants.FieldVirtualMachineAccessCredentials,
+			Parser: func(i interface{}) error {
+				r := i.(map[string]interface{})
+				ac, err := parseAccessCredential(r)
+				if err != nil {
+					return err
+				}
+				vmBuilder.VirtualMachine.Spec.Template.Spec.AccessCredentials = append(
+					vmBuilder.VirtualMachine.Spec.Template.Spec.AccessCredentials, ac)
+				return nil
+			},
+		},
+		{
+			Field: constants.FieldVirtualMachineDNSPolicy,
+			Parser: func(i interface{}) error {
+				if val := i.(string); val != "" {
+					vmBuilder.VirtualMachine.Spec.Template.Spec.DNSPolicy = corev1.DNSPolicy(val)
+				}
+				return nil
+			},
+		},
+		{
+			Field: constants.FieldVirtualMachineDNSConfig,
+			Parser: func(i interface{}) error {
+				r := i.(map[string]interface{})
+				vmBuilder.VirtualMachine.Spec.Template.Spec.DNSConfig = parseDNSConfig(r)
+				return nil
+			},
+		},
 	}
 	return append(processors, customProcessors...)
 }
@@ -496,6 +546,89 @@ func Creator(c *client.Client, ctx context.Context, namespace, name string) util
 	return newVMConstructor(c, ctx, vmBuilder)
 }
 
+func parseAccessCredential(r map[string]interface{}) (kubevirtv1.AccessCredential, error) {
+	sshList, hasSSH := r[constants.FieldAccessCredentialSSHPublicKey].([]interface{})
+	pwList, hasPW := r[constants.FieldAccessCredentialUserPassword].([]interface{})
+
+	if hasSSH && len(sshList) > 0 && hasPW && len(pwList) > 0 {
+		return kubevirtv1.AccessCredential{}, errors.New("access_credentials entry must have either ssh_public_key or user_password, not both")
+	}
+
+	if hasSSH && len(sshList) > 0 {
+		ssh := sshList[0].(map[string]interface{})
+		secretName := ssh[constants.FieldAccessCredentialSecretName].(string)
+		method := ssh[constants.FieldAccessCredentialPropagationMethod].(string)
+		ac := kubevirtv1.AccessCredential{
+			SSHPublicKey: &kubevirtv1.SSHPublicKeyAccessCredential{
+				Source: kubevirtv1.SSHPublicKeyAccessCredentialSource{
+					Secret: &kubevirtv1.AccessCredentialSecretSource{SecretName: secretName},
+				},
+			},
+		}
+		switch method {
+		case "configDrive":
+			ac.SSHPublicKey.PropagationMethod.ConfigDrive = &kubevirtv1.ConfigDriveSSHPublicKeyAccessCredentialPropagation{}
+		case "noCloud":
+			ac.SSHPublicKey.PropagationMethod.NoCloud = &kubevirtv1.NoCloudSSHPublicKeyAccessCredentialPropagation{}
+		case "qemuGuestAgent":
+			var users []string
+			if uList, ok := ssh[constants.FieldAccessCredentialUsers].([]interface{}); ok {
+				for _, u := range uList {
+					users = append(users, u.(string))
+				}
+			}
+			ac.SSHPublicKey.PropagationMethod.QemuGuestAgent = &kubevirtv1.QemuGuestAgentSSHPublicKeyAccessCredentialPropagation{
+				Users: users,
+			}
+		}
+		return ac, nil
+	}
+
+	if hasPW && len(pwList) > 0 {
+		pw := pwList[0].(map[string]interface{})
+		secretName := pw[constants.FieldAccessCredentialSecretName].(string)
+		return kubevirtv1.AccessCredential{
+			UserPassword: &kubevirtv1.UserPasswordAccessCredential{
+				Source: kubevirtv1.UserPasswordAccessCredentialSource{
+					Secret: &kubevirtv1.AccessCredentialSecretSource{SecretName: secretName},
+				},
+				PropagationMethod: kubevirtv1.UserPasswordAccessCredentialPropagationMethod{
+					QemuGuestAgent: &kubevirtv1.QemuGuestAgentUserPasswordAccessCredentialPropagation{},
+				},
+			},
+		}, nil
+	}
+
+	return kubevirtv1.AccessCredential{}, errors.New("access_credentials entry must have either ssh_public_key or user_password")
+}
+
+func parseDNSConfig(r map[string]interface{}) *corev1.PodDNSConfig {
+	config := &corev1.PodDNSConfig{}
+	if ns, ok := r[constants.FieldDNSConfigNameservers].([]interface{}); ok {
+		for _, n := range ns {
+			config.Nameservers = append(config.Nameservers, n.(string))
+		}
+	}
+	if ss, ok := r[constants.FieldDNSConfigSearches].([]interface{}); ok {
+		for _, s := range ss {
+			config.Searches = append(config.Searches, s.(string))
+		}
+	}
+	if opts, ok := r[constants.FieldDNSConfigOptions].([]interface{}); ok {
+		for _, o := range opts {
+			opt := o.(map[string]interface{})
+			dnsOpt := corev1.PodDNSConfigOption{
+				Name: opt[constants.FieldDNSOptionName].(string),
+			}
+			if val, ok := opt[constants.FieldDNSOptionValue].(string); ok && val != "" {
+				dnsOpt.Value = &val
+			}
+			config.Options = append(config.Options, dnsOpt)
+		}
+	}
+	return config
+}
+
 func Updater(c *client.Client, ctx context.Context, vm *kubevirtv1.VirtualMachine) util.Constructor {
 	vm.Spec.Template.Spec.Networks = []kubevirtv1.Network{}
 	vm.Spec.Template.Spec.Domain.Devices.TPM = nil
@@ -503,6 +636,9 @@ func Updater(c *client.Client, ctx context.Context, vm *kubevirtv1.VirtualMachin
 	vm.Spec.Template.Spec.Domain.Devices.Disks = []kubevirtv1.Disk{}
 	vm.Spec.Template.Spec.Domain.Devices.Inputs = []kubevirtv1.Input{}
 	vm.Spec.Template.Spec.Volumes = []kubevirtv1.Volume{}
+	vm.Spec.Template.Spec.AccessCredentials = nil
+	vm.Spec.Template.Spec.DNSPolicy = ""
+	vm.Spec.Template.Spec.DNSConfig = nil
 	vm.Annotations[harvesterutil.AnnotationVolumeClaimTemplates] = "[]"
 	return newVMConstructor(c, ctx, &builder.VMBuilder{
 		VirtualMachine: vm,

--- a/internal/provider/virtualmachine/schema_virtualmachine.go
+++ b/internal/provider/virtualmachine/schema_virtualmachine.go
@@ -200,6 +200,34 @@ please use %s instead of this deprecated field:
 				},
 			},
 		},
+		constants.FieldVirtualMachineAccessCredentials: {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: resourceAccessCredentialSchema(),
+			},
+			Description: "Access credentials for the VM (SSH public keys or user passwords)",
+		},
+		constants.FieldVirtualMachineDNSPolicy: {
+			Type:     schema.TypeString,
+			Optional: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				"ClusterFirst",
+				"ClusterFirstWithHostNet",
+				"Default",
+				"None",
+			}, false),
+			Description: "DNS policy for the VM pod: ClusterFirst, ClusterFirstWithHostNet, Default, or None",
+		},
+		constants.FieldVirtualMachineDNSConfig: {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: resourceDNSConfigSchema(),
+			},
+			Description: "DNS configuration for the VM pod",
+		},
 	}
 	util.NamespacedSchemaWrap(s, false)
 	s[constants.FieldCommonTags].Description = "The tag is reflected as label on the VM.\n" +

--- a/internal/provider/virtualmachine/schema_virtualmachine_access_credential.go
+++ b/internal/provider/virtualmachine/schema_virtualmachine_access_credential.go
@@ -1,0 +1,61 @@
+package virtualmachine
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/harvester/terraform-provider-harvester/pkg/constants"
+)
+
+func resourceAccessCredentialSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		constants.FieldAccessCredentialSSHPublicKey: {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					constants.FieldAccessCredentialSecretName: {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "Name of the Kubernetes secret containing SSH public keys",
+					},
+					constants.FieldAccessCredentialPropagationMethod: {
+						Type:     schema.TypeString,
+						Required: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							"configDrive",
+							"noCloud",
+							"qemuGuestAgent",
+						}, false),
+						Description: "Method to propagate SSH keys: configDrive, noCloud, or qemuGuestAgent",
+					},
+					constants.FieldAccessCredentialUsers: {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+						Description: "List of guest users for qemuGuestAgent propagation (required when propagation_method is qemuGuestAgent)",
+					},
+				},
+			},
+			Description: "SSH public key access credential sourced from a Kubernetes secret",
+		},
+		constants.FieldAccessCredentialUserPassword: {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					constants.FieldAccessCredentialSecretName: {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "Name of the Kubernetes secret containing user passwords",
+					},
+				},
+			},
+			Description: "User password access credential sourced from a Kubernetes secret, propagated via qemu guest agent",
+		},
+	}
+}

--- a/internal/provider/virtualmachine/schema_virtualmachine_disk.go
+++ b/internal/provider/virtualmachine/schema_virtualmachine_disk.go
@@ -110,6 +110,16 @@ func resourceDiskSchema() map[string]*schema.Schema {
 			Computed:     true,
 			ValidateFunc: util.IsValidName,
 		},
+		constants.FieldDiskConfigMapName: {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Name of a ConfigMap to mount as a disk volume",
+		},
+		constants.FieldDiskSecretName: {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Name of a Secret to mount as a disk volume",
+		},
 	}
 	return s
 }

--- a/internal/provider/virtualmachine/schema_virtualmachine_dns.go
+++ b/internal/provider/virtualmachine/schema_virtualmachine_dns.go
@@ -1,0 +1,47 @@
+package virtualmachine
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/harvester/terraform-provider-harvester/pkg/constants"
+)
+
+func resourceDNSConfigSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		constants.FieldDNSConfigNameservers: {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			Description: "List of DNS nameservers",
+		},
+		constants.FieldDNSConfigSearches: {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			Description: "List of DNS search domains",
+		},
+		constants.FieldDNSConfigOptions: {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					constants.FieldDNSOptionName: {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "DNS option name",
+					},
+					constants.FieldDNSOptionValue: {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "DNS option value",
+					},
+				},
+			},
+			Description: "List of DNS resolver options",
+		},
+	}
+}

--- a/internal/tests/resource_virtualmachine_batch2_test.go
+++ b/internal/tests/resource_virtualmachine_batch2_test.go
@@ -1,0 +1,337 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	"github.com/harvester/terraform-provider-harvester/internal/config"
+	"github.com/harvester/terraform-provider-harvester/pkg/constants"
+)
+
+func TestAccVirtualMachine_dns_config(t *testing.T) {
+	var (
+		testAccName         = "test-acc-dns-" + uuid.New().String()[:6]
+		testAccResourceName = constants.ResourceTypeVirtualMachine + "." + testAccName
+		vm                  = &kubevirtv1.VirtualMachine{}
+		ctx                 = context.Background()
+	)
+
+	vmConfig := fmt.Sprintf(`
+resource %s "%s" {
+	name = "%s"
+
+	cpu    = 1
+	memory = "1Gi"
+
+	run_strategy = "RerunOnFailure"
+	machine_type = "q35"
+
+	dns_policy = "None"
+
+	dns_config {
+		nameservers = ["8.8.8.8", "8.8.4.4"]
+		searches    = ["example.com", "test.local"]
+
+		options {
+			name  = "ndots"
+			value = "5"
+		}
+		options {
+			name = "single-request-reopen"
+		}
+	}
+
+	network_interface {
+		name = "default"
+	}
+
+	disk {
+		name               = "rootdisk"
+		type               = "disk"
+		bus                = "virtio"
+		boot_order         = 1
+		container_image_name = "%s"
+	}
+}
+`, constants.ResourceTypeVirtualMachine, testAccName, testAccName, fedoraCloudContainer)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVirtualMachineDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: vmConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccVirtualMachineExists(ctx, testAccResourceName, vm),
+					resource.TestCheckResourceAttr(testAccResourceName, constants.FieldVirtualMachineDNSPolicy, "None"),
+					resource.TestCheckResourceAttr(testAccResourceName, constants.FieldVirtualMachineDNSConfig+".#", "1"),
+					resource.TestCheckResourceAttr(testAccResourceName, constants.FieldVirtualMachineDNSConfig+".0.nameservers.#", "2"),
+					resource.TestCheckResourceAttr(testAccResourceName, constants.FieldVirtualMachineDNSConfig+".0.nameservers.0", "8.8.8.8"),
+					resource.TestCheckResourceAttr(testAccResourceName, constants.FieldVirtualMachineDNSConfig+".0.nameservers.1", "8.8.4.4"),
+					resource.TestCheckResourceAttr(testAccResourceName, constants.FieldVirtualMachineDNSConfig+".0.searches.#", "2"),
+					resource.TestCheckResourceAttr(testAccResourceName, constants.FieldVirtualMachineDNSConfig+".0.options.#", "2"),
+					resource.TestCheckResourceAttr(testAccResourceName, constants.FieldVirtualMachineDNSConfig+".0.options.0.name", "ndots"),
+					resource.TestCheckResourceAttr(testAccResourceName, constants.FieldVirtualMachineDNSConfig+".0.options.0.value", "5"),
+					testAccCheckVMDNSConfig(ctx, testAccResourceName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVirtualMachine_access_credentials(t *testing.T) {
+	var (
+		testAccName         = "test-acc-acred-" + uuid.New().String()[:6]
+		testAccNamespace    = "default"
+		testAccResourceName = constants.ResourceTypeVirtualMachine + "." + testAccName
+		secretName          = "test-ssh-keys-" + uuid.New().String()[:6]
+		vm                  = &kubevirtv1.VirtualMachine{}
+		ctx                 = context.Background()
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccCreateSecret(t, ctx, testAccNamespace, secretName, map[string][]byte{
+				"key1": []byte("ssh-ed25519 AAAA... test@example.com"),
+			})
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVirtualMachineDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource %s "%s" {
+	name = "%s"
+
+	cpu    = 1
+	memory = "1Gi"
+
+	run_strategy = "RerunOnFailure"
+	machine_type = "q35"
+
+	access_credentials {
+		ssh_public_key {
+			secret_name        = "%s"
+			propagation_method = "noCloud"
+		}
+	}
+
+	network_interface {
+		name = "default"
+	}
+
+	disk {
+		name               = "rootdisk"
+		type               = "disk"
+		bus                = "virtio"
+		boot_order         = 1
+		container_image_name = "%s"
+	}
+}
+`, constants.ResourceTypeVirtualMachine, testAccName, testAccName, secretName, fedoraCloudContainer),
+				Check: resource.ComposeTestCheckFunc(
+					testAccVirtualMachineExists(ctx, testAccResourceName, vm),
+					resource.TestCheckResourceAttr(testAccResourceName, constants.FieldVirtualMachineAccessCredentials+".#", "1"),
+					resource.TestCheckResourceAttr(testAccResourceName, constants.FieldVirtualMachineAccessCredentials+".0.ssh_public_key.#", "1"),
+					resource.TestCheckResourceAttr(testAccResourceName, constants.FieldVirtualMachineAccessCredentials+".0.ssh_public_key.0.secret_name", secretName),
+					resource.TestCheckResourceAttr(testAccResourceName, constants.FieldVirtualMachineAccessCredentials+".0.ssh_public_key.0.propagation_method", "noCloud"),
+					testAccCheckVMAccessCredentials(ctx, testAccResourceName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVirtualMachine_configmap_disk(t *testing.T) {
+	var (
+		testAccName         = "test-acc-cmdisk-" + uuid.New().String()[:6]
+		testAccNamespace    = "default"
+		testAccResourceName = constants.ResourceTypeVirtualMachine + "." + testAccName
+		configMapName       = "test-cm-" + uuid.New().String()[:6]
+		vm                  = &kubevirtv1.VirtualMachine{}
+		ctx                 = context.Background()
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccCreateConfigMap(t, ctx, testAccNamespace, configMapName, map[string]string{
+				"config.yaml": "key: value",
+			})
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVirtualMachineDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource %s "%s" {
+	name = "%s"
+
+	cpu    = 1
+	memory = "1Gi"
+
+	run_strategy = "RerunOnFailure"
+	machine_type = "q35"
+
+	network_interface {
+		name = "default"
+	}
+
+	disk {
+		name               = "rootdisk"
+		type               = "disk"
+		bus                = "virtio"
+		boot_order         = 1
+		container_image_name = "%s"
+	}
+
+	disk {
+		name           = "config-disk"
+		type           = "disk"
+		bus            = "virtio"
+		configmap_name = "%s"
+	}
+}
+`, constants.ResourceTypeVirtualMachine, testAccName, testAccName, fedoraCloudContainer, configMapName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccVirtualMachineExists(ctx, testAccResourceName, vm),
+					resource.TestCheckResourceAttr(testAccResourceName, constants.FieldVirtualMachineDisk+".#", "2"),
+					resource.TestCheckResourceAttr(testAccResourceName, constants.FieldVirtualMachineDisk+".1.configmap_name", configMapName),
+					testAccCheckVMConfigMapVolume(ctx, testAccResourceName, configMapName),
+				),
+			},
+		},
+	})
+}
+
+// testAccCreateSecret creates a K8s secret as a test prerequisite.
+func testAccCreateSecret(t *testing.T, ctx context.Context, namespace, name string, data map[string][]byte) {
+	t.Helper()
+	c, err := testAccProvider.Meta().(*config.Config).K8sClient()
+	if err != nil {
+		t.Fatalf("failed to get k8s client: %v", err)
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: data,
+	}
+	_, err = c.KubeClient.CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create test secret %s: %v", name, err)
+	}
+	t.Cleanup(func() {
+		_ = c.KubeClient.CoreV1().Secrets(namespace).Delete(ctx, name, metav1.DeleteOptions{}) //nolint:errcheck
+	})
+}
+
+// testAccCreateConfigMap creates a K8s ConfigMap as a test prerequisite.
+func testAccCreateConfigMap(t *testing.T, ctx context.Context, namespace, name string, data map[string]string) {
+	t.Helper()
+	c, err := testAccProvider.Meta().(*config.Config).K8sClient()
+	if err != nil {
+		t.Fatalf("failed to get k8s client: %v", err)
+	}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: data,
+	}
+	_, err = c.KubeClient.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create test configmap %s: %v", name, err)
+	}
+	t.Cleanup(func() {
+		_ = c.KubeClient.CoreV1().ConfigMaps(namespace).Delete(ctx, name, metav1.DeleteOptions{}) //nolint:errcheck
+	})
+}
+
+// testAccCheckVMDNSConfig verifies the K8s VM object has the expected DNS configuration.
+func testAccCheckVMDNSConfig(ctx context.Context, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		vm, err := testAccGetVirtualMachine(ctx, s, n)
+		if err != nil {
+			return err
+		}
+		if vm.Spec.Template == nil {
+			return fmt.Errorf("VM template is nil")
+		}
+		if vm.Spec.Template.Spec.DNSPolicy != corev1.DNSNone {
+			return fmt.Errorf("expected DNS policy None, got %s", vm.Spec.Template.Spec.DNSPolicy)
+		}
+		dnsConfig := vm.Spec.Template.Spec.DNSConfig
+		if dnsConfig == nil {
+			return fmt.Errorf("DNS config is nil")
+		}
+		if len(dnsConfig.Nameservers) != 2 || dnsConfig.Nameservers[0] != "8.8.8.8" {
+			return fmt.Errorf("unexpected nameservers: %v", dnsConfig.Nameservers)
+		}
+		if len(dnsConfig.Searches) != 2 || dnsConfig.Searches[0] != "example.com" {
+			return fmt.Errorf("unexpected searches: %v", dnsConfig.Searches)
+		}
+		if len(dnsConfig.Options) != 2 {
+			return fmt.Errorf("expected 2 DNS options, got %d", len(dnsConfig.Options))
+		}
+		return nil
+	}
+}
+
+// testAccCheckVMAccessCredentials verifies the K8s VM object has access credentials.
+func testAccCheckVMAccessCredentials(ctx context.Context, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		vm, err := testAccGetVirtualMachine(ctx, s, n)
+		if err != nil {
+			return err
+		}
+		if vm.Spec.Template == nil {
+			return fmt.Errorf("VM template is nil")
+		}
+		creds := vm.Spec.Template.Spec.AccessCredentials
+		if len(creds) != 1 {
+			return fmt.Errorf("expected 1 access credential, got %d", len(creds))
+		}
+		if creds[0].SSHPublicKey == nil {
+			return fmt.Errorf("expected SSH public key credential, got nil")
+		}
+		if creds[0].SSHPublicKey.Source.Secret == nil {
+			return fmt.Errorf("expected SSH public key source secret, got nil")
+		}
+		if creds[0].SSHPublicKey.PropagationMethod.NoCloud == nil {
+			return fmt.Errorf("expected noCloud propagation method")
+		}
+		return nil
+	}
+}
+
+// testAccCheckVMConfigMapVolume verifies the K8s VM object has a ConfigMap volume.
+func testAccCheckVMConfigMapVolume(ctx context.Context, n, configMapName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		vm, err := testAccGetVirtualMachine(ctx, s, n)
+		if err != nil {
+			return err
+		}
+		if vm.Spec.Template == nil {
+			return fmt.Errorf("VM template is nil")
+		}
+		for _, vol := range vm.Spec.Template.Spec.Volumes {
+			if vol.ConfigMap != nil && vol.ConfigMap.Name == configMapName {
+				return nil
+			}
+		}
+		return fmt.Errorf("configmap volume %s not found in VM volumes", configMapName)
+	}
+}

--- a/pkg/constants/constants_virtualmachine.go
+++ b/pkg/constants/constants_virtualmachine.go
@@ -29,6 +29,9 @@ const (
 	FieldVirtualMachineNodeSelector          = "node_selector"
 	FieldVirtualMachineCreateInitialSnapshot = "create_initial_snapshot"
 	FieldVirtualMachineHostDevice            = "host_device"
+	FieldVirtualMachineAccessCredentials     = "access_credentials"
+	FieldVirtualMachineDNSPolicy             = "dns_policy"
+	FieldVirtualMachineDNSConfig             = "dns_config"
 
 	StateVirtualMachineStarting = "Starting"
 	StateVirtualMachineRunning  = "Running"
@@ -75,6 +78,8 @@ const (
 	FieldDiskHotPlug            = "hot_plug"
 	FieldDiskAutoDelete         = "auto_delete"
 	FieldDiskVolumeName         = "volume_name"
+	FieldDiskConfigMapName      = "configmap_name"
+	FieldDiskSecretName         = "secret_name"
 
 	AnnotationDiskAutoDelete = "terraform-provider-harvester-auto-delete"
 )
@@ -102,4 +107,20 @@ const (
 const (
 	FieldHostDeviceName       = "name"
 	FieldHostDeviceDeviceName = "device_name"
+)
+
+const (
+	FieldAccessCredentialSSHPublicKey      = "ssh_public_key"     // #nosec G101
+	FieldAccessCredentialUserPassword      = "user_password"      // #nosec G101
+	FieldAccessCredentialSecretName        = "secret_name"        // #nosec G101
+	FieldAccessCredentialPropagationMethod = "propagation_method" // #nosec G101
+	FieldAccessCredentialUsers             = "users"
+)
+
+const (
+	FieldDNSConfigNameservers = "nameservers"
+	FieldDNSConfigSearches    = "searches"
+	FieldDNSConfigOptions     = "options"
+	FieldDNSOptionName        = "name"
+	FieldDNSOptionValue       = "value"
 )

--- a/pkg/importer/resource_virtualmachine_importer.go
+++ b/pkg/importer/resource_virtualmachine_importer.go
@@ -329,6 +329,10 @@ func (v *VMImporter) Volume() ([]map[string]interface{}, []map[string]interface{
 					}
 				} else if volume.ContainerDisk != nil {
 					diskState[constants.FieldDiskContainerImageName] = volume.ContainerDisk.Image
+				} else if volume.ConfigMap != nil {
+					diskState[constants.FieldDiskConfigMapName] = volume.ConfigMap.Name
+				} else if volume.Secret != nil {
+					diskState[constants.FieldDiskSecretName] = volume.Secret.SecretName
 				} else {
 					return nil, nil, fmt.Errorf("unsupported volume type found on volume %s. ", volume.Name)
 				}
@@ -337,6 +341,70 @@ func (v *VMImporter) Volume() ([]map[string]interface{}, []map[string]interface{
 		diskStates = append(diskStates, diskState)
 	}
 	return diskStates, cloudInitState, nil
+}
+
+func (v *VMImporter) AccessCredentials() []map[string]interface{} {
+	acs := v.VirtualMachine.Spec.Template.Spec.AccessCredentials
+	result := make([]map[string]interface{}, 0, len(acs))
+	for _, ac := range acs {
+		entry := map[string]interface{}{}
+		if ac.SSHPublicKey != nil {
+			ssh := map[string]interface{}{}
+			if ac.SSHPublicKey.Source.Secret != nil {
+				ssh[constants.FieldAccessCredentialSecretName] = ac.SSHPublicKey.Source.Secret.SecretName
+			}
+			pm := ac.SSHPublicKey.PropagationMethod
+			switch {
+			case pm.ConfigDrive != nil:
+				ssh[constants.FieldAccessCredentialPropagationMethod] = "configDrive"
+			case pm.NoCloud != nil:
+				ssh[constants.FieldAccessCredentialPropagationMethod] = "noCloud"
+			case pm.QemuGuestAgent != nil:
+				ssh[constants.FieldAccessCredentialPropagationMethod] = "qemuGuestAgent"
+				ssh[constants.FieldAccessCredentialUsers] = pm.QemuGuestAgent.Users
+			}
+			entry[constants.FieldAccessCredentialSSHPublicKey] = []interface{}{ssh}
+			entry[constants.FieldAccessCredentialUserPassword] = []interface{}{}
+		} else if ac.UserPassword != nil {
+			pw := map[string]interface{}{}
+			if ac.UserPassword.Source.Secret != nil {
+				pw[constants.FieldAccessCredentialSecretName] = ac.UserPassword.Source.Secret.SecretName
+			}
+			entry[constants.FieldAccessCredentialUserPassword] = []interface{}{pw}
+			entry[constants.FieldAccessCredentialSSHPublicKey] = []interface{}{}
+		}
+		result = append(result, entry)
+	}
+	return result
+}
+
+func (v *VMImporter) DNSPolicy() string {
+	return string(v.VirtualMachine.Spec.Template.Spec.DNSPolicy)
+}
+
+func (v *VMImporter) DNSConfig() []map[string]interface{} {
+	dc := v.VirtualMachine.Spec.Template.Spec.DNSConfig
+	if dc == nil {
+		return nil
+	}
+	result := map[string]interface{}{
+		constants.FieldDNSConfigNameservers: dc.Nameservers,
+		constants.FieldDNSConfigSearches:    dc.Searches,
+	}
+	opts := make([]map[string]interface{}, 0, len(dc.Options))
+	for _, o := range dc.Options {
+		opt := map[string]interface{}{
+			constants.FieldDNSOptionName: o.Name,
+		}
+		if o.Value != nil {
+			opt[constants.FieldDNSOptionValue] = *o.Value
+		} else {
+			opt[constants.FieldDNSOptionValue] = ""
+		}
+		opts = append(opts, opt)
+	}
+	result[constants.FieldDNSConfigOptions] = opts
+	return []map[string]interface{}{result}
 }
 
 func (v *VMImporter) NodeName() string {
@@ -432,6 +500,9 @@ func ResourceVirtualMachineStateGetter(vm *kubevirtv1.VirtualMachine, vmi *kubev
 			constants.FieldVirtualMachineCPUPinning:            vmImporter.DedicatedCPUPlacement(),
 			constants.FieldVirtualMachineIsolateEmulatorThread: vmImporter.IsolateEmulatorThread(),
 			constants.FieldVirtualMachineNodeSelector:          vm.Spec.Template.Spec.NodeSelector,
+			constants.FieldVirtualMachineAccessCredentials:     vmImporter.AccessCredentials(),
+			constants.FieldVirtualMachineDNSPolicy:             vmImporter.DNSPolicy(),
+			constants.FieldVirtualMachineDNSConfig:             vmImporter.DNSConfig(),
 		},
 	}, nil
 }

--- a/pkg/importer/resource_virtualmachine_importer.go
+++ b/pkg/importer/resource_virtualmachine_importer.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
@@ -250,12 +251,29 @@ func (v *VMImporter) pvcVolume(volume kubevirtv1.Volume, state map[string]interf
 	return nil
 }
 
+// stripInjectedSSHUser removes the "user: <name>" line the provider appends to
+// cloudinit.user_data from the VM's `ssh-user` tag on create, so reading the
+// VM back does not report a permanent diff.
+func (v *VMImporter) stripInjectedSSHUser(userData string) string {
+	sshUser := v.VirtualMachine.Labels[builder.LabelPrefixHarvesterTag+constants.LabelSSHUsername]
+	if sshUser == "" {
+		return userData
+	}
+	if userData == fmt.Sprintf("#cloud-config\nuser: %s\n", sshUser) {
+		return ""
+	}
+	if suffix := fmt.Sprintf("\nuser: %s\n", sshUser); strings.HasSuffix(userData, suffix) {
+		return strings.TrimSuffix(userData, suffix)
+	}
+	return userData
+}
+
 func (v *VMImporter) cloudInit(volume kubevirtv1.Volume) []map[string]interface{} {
 	var cloudInitState = make([]map[string]interface{}, 0, 1)
 	if volume.CloudInitNoCloud != nil {
 		cloudInitState = append(cloudInitState, map[string]interface{}{
 			constants.FieldCloudInitType:              builder.CloudInitTypeNoCloud,
-			constants.FieldCloudInitUserData:          volume.CloudInitNoCloud.UserData,
+			constants.FieldCloudInitUserData:          v.stripInjectedSSHUser(volume.CloudInitNoCloud.UserData),
 			constants.FieldCloudInitUserDataBase64:    volume.CloudInitNoCloud.UserDataBase64,
 			constants.FieldCloudInitNetworkData:       volume.CloudInitNoCloud.NetworkData,
 			constants.FieldCloudInitNetworkDataBase64: volume.CloudInitNoCloud.NetworkDataBase64,
@@ -269,7 +287,7 @@ func (v *VMImporter) cloudInit(volume kubevirtv1.Volume) []map[string]interface{
 	} else if volume.CloudInitConfigDrive != nil {
 		cloudInitState = append(cloudInitState, map[string]interface{}{
 			constants.FieldCloudInitType:              builder.CloudInitTypeConfigDrive,
-			constants.FieldCloudInitUserData:          volume.CloudInitConfigDrive.UserData,
+			constants.FieldCloudInitUserData:          v.stripInjectedSSHUser(volume.CloudInitConfigDrive.UserData),
 			constants.FieldCloudInitUserDataBase64:    volume.CloudInitConfigDrive.UserDataBase64,
 			constants.FieldCloudInitNetworkData:       volume.CloudInitConfigDrive.NetworkData,
 			constants.FieldCloudInitNetworkDataBase64: volume.CloudInitConfigDrive.NetworkDataBase64,

--- a/pkg/importer/resource_virtualmachine_importer.go
+++ b/pkg/importer/resource_virtualmachine_importer.go
@@ -329,6 +329,10 @@ func (v *VMImporter) Volume() ([]map[string]interface{}, []map[string]interface{
 					}
 				} else if volume.ContainerDisk != nil {
 					diskState[constants.FieldDiskContainerImageName] = volume.ContainerDisk.Image
+				} else if volume.ConfigMap != nil {
+					diskState[constants.FieldDiskConfigMapName] = volume.ConfigMap.Name
+				} else if volume.Secret != nil {
+					diskState[constants.FieldDiskSecretName] = volume.Secret.SecretName
 				} else {
 					return nil, nil, fmt.Errorf("unsupported volume type found on volume %s. ", volume.Name)
 				}
@@ -337,6 +341,70 @@ func (v *VMImporter) Volume() ([]map[string]interface{}, []map[string]interface{
 		diskStates = append(diskStates, diskState)
 	}
 	return diskStates, cloudInitState, nil
+}
+
+func (v *VMImporter) AccessCredentials() []map[string]interface{} {
+	acs := v.VirtualMachine.Spec.Template.Spec.AccessCredentials
+	result := make([]map[string]interface{}, 0, len(acs))
+	for _, ac := range acs {
+		entry := map[string]interface{}{}
+		if ac.SSHPublicKey != nil {
+			ssh := map[string]interface{}{}
+			if ac.SSHPublicKey.Source.Secret != nil {
+				ssh[constants.FieldAccessCredentialSecretName] = ac.SSHPublicKey.Source.Secret.SecretName
+			}
+			pm := ac.SSHPublicKey.PropagationMethod
+			switch {
+			case pm.ConfigDrive != nil:
+				ssh[constants.FieldAccessCredentialPropagationMethod] = "configDrive"
+			case pm.NoCloud != nil:
+				ssh[constants.FieldAccessCredentialPropagationMethod] = "noCloud"
+			case pm.QemuGuestAgent != nil:
+				ssh[constants.FieldAccessCredentialPropagationMethod] = "qemuGuestAgent"
+				ssh[constants.FieldAccessCredentialUsers] = pm.QemuGuestAgent.Users
+			}
+			entry[constants.FieldAccessCredentialSSHPublicKey] = []interface{}{ssh}
+			entry[constants.FieldAccessCredentialUserPassword] = []interface{}{}
+		} else if ac.UserPassword != nil {
+			pw := map[string]interface{}{}
+			if ac.UserPassword.Source.Secret != nil {
+				pw[constants.FieldAccessCredentialSecretName] = ac.UserPassword.Source.Secret.SecretName
+			}
+			entry[constants.FieldAccessCredentialUserPassword] = []interface{}{pw}
+			entry[constants.FieldAccessCredentialSSHPublicKey] = []interface{}{}
+		}
+		result = append(result, entry)
+	}
+	return result
+}
+
+func (v *VMImporter) DNSPolicy() string {
+	return string(v.VirtualMachine.Spec.Template.Spec.DNSPolicy)
+}
+
+func (v *VMImporter) DNSConfig() []map[string]interface{} {
+	dc := v.VirtualMachine.Spec.Template.Spec.DNSConfig
+	if dc == nil {
+		return nil
+	}
+	result := map[string]interface{}{
+		constants.FieldDNSConfigNameservers: dc.Nameservers,
+		constants.FieldDNSConfigSearches:    dc.Searches,
+	}
+	opts := make([]map[string]interface{}, 0, len(dc.Options))
+	for _, o := range dc.Options {
+		opt := map[string]interface{}{
+			constants.FieldDNSOptionName: o.Name,
+		}
+		if o.Value != nil {
+			opt[constants.FieldDNSOptionValue] = *o.Value
+		} else {
+			opt[constants.FieldDNSOptionValue] = ""
+		}
+		opts = append(opts, opt)
+	}
+	result[constants.FieldDNSConfigOptions] = opts
+	return []map[string]interface{}{result}
 }
 
 func (v *VMImporter) NodeName() string {
@@ -435,6 +503,9 @@ func ResourceVirtualMachineStateGetter(vm *kubevirtv1.VirtualMachine, vmi *kubev
 			constants.FieldVirtualMachineCPUPinning:            vmImporter.DedicatedCPUPlacement(),
 			constants.FieldVirtualMachineIsolateEmulatorThread: vmImporter.IsolateEmulatorThread(),
 			constants.FieldVirtualMachineNodeSelector:          vm.Spec.Template.Spec.NodeSelector,
+			constants.FieldVirtualMachineAccessCredentials:     vmImporter.AccessCredentials(),
+			constants.FieldVirtualMachineDNSPolicy:             vmImporter.DNSPolicy(),
+			constants.FieldVirtualMachineDNSConfig:             vmImporter.DNSConfig(),
 		},
 	}, nil
 }

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -3,9 +3,12 @@ package importer
 import (
 	"testing"
 
+	"reflect"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/harvester/harvester/pkg/builder"
@@ -563,5 +566,214 @@ func TestResourceRequestsImport(t *testing.T) {
 	}
 	if got := reqsNil[0][constants.FieldRequestsMemory]; got != "" {
 		t.Errorf("Requests() nil memory = %q, want empty", got)
+	}
+}
+
+func TestAccessCredentialsImport(t *testing.T) {
+	// VM with SSH public key via qemuGuestAgent
+	vm := &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					AccessCredentials: []kubevirtv1.AccessCredential{
+						{
+							SSHPublicKey: &kubevirtv1.SSHPublicKeyAccessCredential{
+								Source: kubevirtv1.SSHPublicKeyAccessCredentialSource{
+									Secret: &kubevirtv1.AccessCredentialSecretSource{SecretName: "my-ssh-keys"}, // #nosec G101
+								},
+								PropagationMethod: kubevirtv1.SSHPublicKeyAccessCredentialPropagationMethod{
+									QemuGuestAgent: &kubevirtv1.QemuGuestAgentSSHPublicKeyAccessCredentialPropagation{
+										Users: []string{"root", "admin"},
+									},
+								},
+							},
+						},
+						{
+							UserPassword: &kubevirtv1.UserPasswordAccessCredential{
+								Source: kubevirtv1.UserPasswordAccessCredentialSource{
+									Secret: &kubevirtv1.AccessCredentialSecretSource{SecretName: "my-passwords"},
+								},
+								PropagationMethod: kubevirtv1.UserPasswordAccessCredentialPropagationMethod{
+									QemuGuestAgent: &kubevirtv1.QemuGuestAgentUserPasswordAccessCredentialPropagation{},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	importer := &VMImporter{VirtualMachine: vm}
+	acs := importer.AccessCredentials()
+
+	if len(acs) != 2 {
+		t.Fatalf("AccessCredentials() returned %d entries, want 2", len(acs))
+	}
+
+	// Check SSH entry
+	sshList := acs[0][constants.FieldAccessCredentialSSHPublicKey].([]interface{})
+	if len(sshList) != 1 {
+		t.Fatalf("SSH entry has %d items, want 1", len(sshList))
+	}
+	ssh := sshList[0].(map[string]interface{})
+	if ssh[constants.FieldAccessCredentialSecretName] != "my-ssh-keys" {
+		t.Errorf("SSH secret_name = %q, want %q", ssh[constants.FieldAccessCredentialSecretName], "my-ssh-keys")
+	}
+	if ssh[constants.FieldAccessCredentialPropagationMethod] != "qemuGuestAgent" {
+		t.Errorf("SSH propagation_method = %q, want %q", ssh[constants.FieldAccessCredentialPropagationMethod], "qemuGuestAgent")
+	}
+	users := ssh[constants.FieldAccessCredentialUsers].([]string)
+	if !reflect.DeepEqual(users, []string{"root", "admin"}) {
+		t.Errorf("SSH users = %v, want [root admin]", users)
+	}
+
+	// Check UserPassword entry
+	pwList := acs[1][constants.FieldAccessCredentialUserPassword].([]interface{})
+	if len(pwList) != 1 {
+		t.Fatalf("UserPassword entry has %d items, want 1", len(pwList))
+	}
+	pw := pwList[0].(map[string]interface{})
+	if pw[constants.FieldAccessCredentialSecretName] != "my-passwords" {
+		t.Errorf("UserPassword secret_name = %q, want %q", pw[constants.FieldAccessCredentialSecretName], "my-passwords")
+	}
+
+	// Test empty access credentials
+	vmEmpty := &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{},
+			},
+		},
+	}
+	importerEmpty := &VMImporter{VirtualMachine: vmEmpty}
+	if got := importerEmpty.AccessCredentials(); len(got) != 0 {
+		t.Errorf("AccessCredentials() empty VM returned %d entries, want 0", len(got))
+	}
+}
+
+func TestDNSImport(t *testing.T) {
+	// VM with DNS policy and config
+	vm := &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					DNSPolicy: corev1.DNSNone,
+					DNSConfig: &corev1.PodDNSConfig{
+						Nameservers: []string{"8.8.8.8", "8.8.4.4"},
+						Searches:    []string{"example.com"},
+						Options: []corev1.PodDNSConfigOption{
+							{Name: "ndots", Value: ptr.To("5")},
+							{Name: "single-request"},
+						},
+					},
+				},
+			},
+		},
+	}
+	importer := &VMImporter{VirtualMachine: vm}
+
+	if policy := importer.DNSPolicy(); policy != "None" {
+		t.Errorf("DNSPolicy() = %q, want %q", policy, "None")
+	}
+
+	dc := importer.DNSConfig()
+	if len(dc) != 1 {
+		t.Fatalf("DNSConfig() returned %d entries, want 1", len(dc))
+	}
+	ns := dc[0][constants.FieldDNSConfigNameservers].([]string)
+	if !reflect.DeepEqual(ns, []string{"8.8.8.8", "8.8.4.4"}) {
+		t.Errorf("DNSConfig nameservers = %v, want [8.8.8.8 8.8.4.4]", ns)
+	}
+	searches := dc[0][constants.FieldDNSConfigSearches].([]string)
+	if !reflect.DeepEqual(searches, []string{"example.com"}) {
+		t.Errorf("DNSConfig searches = %v, want [example.com]", searches)
+	}
+	opts := dc[0][constants.FieldDNSConfigOptions].([]map[string]interface{})
+	if len(opts) != 2 {
+		t.Fatalf("DNSConfig options has %d items, want 2", len(opts))
+	}
+	if opts[0][constants.FieldDNSOptionName] != "ndots" || opts[0][constants.FieldDNSOptionValue] != "5" {
+		t.Errorf("DNS option 0 = %v, want {name:ndots, value:5}", opts[0])
+	}
+	if opts[1][constants.FieldDNSOptionName] != "single-request" || opts[1][constants.FieldDNSOptionValue] != "" {
+		t.Errorf("DNS option 1 = %v, want {name:single-request, value:\"\"}", opts[1])
+	}
+
+	// VM without DNS config
+	vmNoDNS := &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{},
+			},
+		},
+	}
+	importerNoDNS := &VMImporter{VirtualMachine: vmNoDNS}
+	if policy := importerNoDNS.DNSPolicy(); policy != "" {
+		t.Errorf("DNSPolicy() empty = %q, want empty", policy)
+	}
+	if dc := importerNoDNS.DNSConfig(); dc != nil {
+		t.Errorf("DNSConfig() empty = %v, want nil", dc)
+	}
+}
+
+func TestConfigMapSecretDiskImport(t *testing.T) {
+	vm := &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Devices: kubevirtv1.Devices{
+							Disks: []kubevirtv1.Disk{
+								{
+									Name: "cm-disk",
+									DiskDevice: kubevirtv1.DiskDevice{
+										Disk: &kubevirtv1.DiskTarget{Bus: "virtio"},
+									},
+								},
+								{
+									Name: "sec-disk",
+									DiskDevice: kubevirtv1.DiskDevice{
+										Disk: &kubevirtv1.DiskTarget{Bus: "virtio"},
+									},
+								},
+							},
+						},
+					},
+					Volumes: []kubevirtv1.Volume{
+						{
+							Name: "cm-disk",
+							VolumeSource: kubevirtv1.VolumeSource{
+								ConfigMap: &kubevirtv1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "my-config"},
+								},
+							},
+						},
+						{
+							Name: "sec-disk",
+							VolumeSource: kubevirtv1.VolumeSource{
+								Secret: &kubevirtv1.SecretVolumeSource{
+									SecretName: "my-secret",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	importer := &VMImporter{VirtualMachine: vm}
+	disks, _, err := importer.Volume()
+	if err != nil {
+		t.Fatalf("Volume() error: %v", err)
+	}
+	if len(disks) != 2 {
+		t.Fatalf("Volume() returned %d disks, want 2", len(disks))
+	}
+	if disks[0][constants.FieldDiskConfigMapName] != "my-config" {
+		t.Errorf("disk 0 configmap_name = %v, want my-config", disks[0][constants.FieldDiskConfigMapName])
+	}
+	if disks[1][constants.FieldDiskSecretName] != "my-secret" {
+		t.Errorf("disk 1 secret_name = %v, want my-secret", disks[1][constants.FieldDiskSecretName])
 	}
 }

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -787,3 +787,63 @@ func TestConfigMapSecretDiskImport(t *testing.T) {
 		t.Errorf("disk 1 secret_name = %v, want my-secret", disks[1][constants.FieldDiskSecretName])
 	}
 }
+
+func TestStripInjectedSSHUser(t *testing.T) {
+	newImporter := func(sshUser string) *VMImporter {
+		labels := map[string]string{}
+		if sshUser != "" {
+			labels[builder.LabelPrefixHarvesterTag+constants.LabelSSHUsername] = sshUser
+		}
+		return &VMImporter{
+			VirtualMachine: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+			},
+		}
+	}
+	testcases := []struct {
+		name     string
+		sshUser  string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no ssh-user tag leaves user_data unchanged",
+			sshUser:  "",
+			input:    "#cloud-config\nuser: sles\n",
+			expected: "#cloud-config\nuser: sles\n",
+		},
+		{
+			name:     "fully injected user_data reads back as empty",
+			sshUser:  "sles",
+			input:    "#cloud-config\nuser: sles\n",
+			expected: "",
+		},
+		{
+			name:     "injected trailing user line is stripped",
+			sshUser:  "sles",
+			input:    "#cloud-config\npackages:\n  - qemu-guest-agent\n\nuser: sles\n",
+			expected: "#cloud-config\npackages:\n  - qemu-guest-agent\n",
+		},
+		{
+			name:     "user line in the middle is kept",
+			sshUser:  "sles",
+			input:    "#cloud-config\nuser: sles\npackages:\n  - vim\n",
+			expected: "#cloud-config\nuser: sles\npackages:\n  - vim\n",
+		},
+		{
+			name:     "trailing user line for another user is kept",
+			sshUser:  "sles",
+			input:    "#cloud-config\n\nuser: opensuse\n",
+			expected: "#cloud-config\n\nuser: opensuse\n",
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := newImporter(tc.sshUser).stripInjectedSSHUser(tc.input); got != tc.expected {
+				t.Errorf("stripInjectedSSHUser() = %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -3,9 +3,12 @@ package importer
 import (
 	"testing"
 
+	"reflect"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/harvester/harvester/pkg/builder"
@@ -573,5 +576,214 @@ func TestResourceRequestsImport(t *testing.T) {
 	}
 	if got := reqsNil[0][constants.FieldRequestsMemory]; got != "" {
 		t.Errorf("Requests() nil memory = %q, want empty", got)
+	}
+}
+
+func TestAccessCredentialsImport(t *testing.T) {
+	// VM with SSH public key via qemuGuestAgent
+	vm := &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					AccessCredentials: []kubevirtv1.AccessCredential{
+						{
+							SSHPublicKey: &kubevirtv1.SSHPublicKeyAccessCredential{
+								Source: kubevirtv1.SSHPublicKeyAccessCredentialSource{
+									Secret: &kubevirtv1.AccessCredentialSecretSource{SecretName: "my-ssh-keys"}, // #nosec G101
+								},
+								PropagationMethod: kubevirtv1.SSHPublicKeyAccessCredentialPropagationMethod{
+									QemuGuestAgent: &kubevirtv1.QemuGuestAgentSSHPublicKeyAccessCredentialPropagation{
+										Users: []string{"root", "admin"},
+									},
+								},
+							},
+						},
+						{
+							UserPassword: &kubevirtv1.UserPasswordAccessCredential{
+								Source: kubevirtv1.UserPasswordAccessCredentialSource{
+									Secret: &kubevirtv1.AccessCredentialSecretSource{SecretName: "my-passwords"},
+								},
+								PropagationMethod: kubevirtv1.UserPasswordAccessCredentialPropagationMethod{
+									QemuGuestAgent: &kubevirtv1.QemuGuestAgentUserPasswordAccessCredentialPropagation{},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	importer := &VMImporter{VirtualMachine: vm}
+	acs := importer.AccessCredentials()
+
+	if len(acs) != 2 {
+		t.Fatalf("AccessCredentials() returned %d entries, want 2", len(acs))
+	}
+
+	// Check SSH entry
+	sshList := acs[0][constants.FieldAccessCredentialSSHPublicKey].([]interface{})
+	if len(sshList) != 1 {
+		t.Fatalf("SSH entry has %d items, want 1", len(sshList))
+	}
+	ssh := sshList[0].(map[string]interface{})
+	if ssh[constants.FieldAccessCredentialSecretName] != "my-ssh-keys" {
+		t.Errorf("SSH secret_name = %q, want %q", ssh[constants.FieldAccessCredentialSecretName], "my-ssh-keys")
+	}
+	if ssh[constants.FieldAccessCredentialPropagationMethod] != "qemuGuestAgent" {
+		t.Errorf("SSH propagation_method = %q, want %q", ssh[constants.FieldAccessCredentialPropagationMethod], "qemuGuestAgent")
+	}
+	users := ssh[constants.FieldAccessCredentialUsers].([]string)
+	if !reflect.DeepEqual(users, []string{"root", "admin"}) {
+		t.Errorf("SSH users = %v, want [root admin]", users)
+	}
+
+	// Check UserPassword entry
+	pwList := acs[1][constants.FieldAccessCredentialUserPassword].([]interface{})
+	if len(pwList) != 1 {
+		t.Fatalf("UserPassword entry has %d items, want 1", len(pwList))
+	}
+	pw := pwList[0].(map[string]interface{})
+	if pw[constants.FieldAccessCredentialSecretName] != "my-passwords" {
+		t.Errorf("UserPassword secret_name = %q, want %q", pw[constants.FieldAccessCredentialSecretName], "my-passwords")
+	}
+
+	// Test empty access credentials
+	vmEmpty := &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{},
+			},
+		},
+	}
+	importerEmpty := &VMImporter{VirtualMachine: vmEmpty}
+	if got := importerEmpty.AccessCredentials(); len(got) != 0 {
+		t.Errorf("AccessCredentials() empty VM returned %d entries, want 0", len(got))
+	}
+}
+
+func TestDNSImport(t *testing.T) {
+	// VM with DNS policy and config
+	vm := &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					DNSPolicy: corev1.DNSNone,
+					DNSConfig: &corev1.PodDNSConfig{
+						Nameservers: []string{"8.8.8.8", "8.8.4.4"},
+						Searches:    []string{"example.com"},
+						Options: []corev1.PodDNSConfigOption{
+							{Name: "ndots", Value: ptr.To("5")},
+							{Name: "single-request"},
+						},
+					},
+				},
+			},
+		},
+	}
+	importer := &VMImporter{VirtualMachine: vm}
+
+	if policy := importer.DNSPolicy(); policy != "None" {
+		t.Errorf("DNSPolicy() = %q, want %q", policy, "None")
+	}
+
+	dc := importer.DNSConfig()
+	if len(dc) != 1 {
+		t.Fatalf("DNSConfig() returned %d entries, want 1", len(dc))
+	}
+	ns := dc[0][constants.FieldDNSConfigNameservers].([]string)
+	if !reflect.DeepEqual(ns, []string{"8.8.8.8", "8.8.4.4"}) {
+		t.Errorf("DNSConfig nameservers = %v, want [8.8.8.8 8.8.4.4]", ns)
+	}
+	searches := dc[0][constants.FieldDNSConfigSearches].([]string)
+	if !reflect.DeepEqual(searches, []string{"example.com"}) {
+		t.Errorf("DNSConfig searches = %v, want [example.com]", searches)
+	}
+	opts := dc[0][constants.FieldDNSConfigOptions].([]map[string]interface{})
+	if len(opts) != 2 {
+		t.Fatalf("DNSConfig options has %d items, want 2", len(opts))
+	}
+	if opts[0][constants.FieldDNSOptionName] != "ndots" || opts[0][constants.FieldDNSOptionValue] != "5" {
+		t.Errorf("DNS option 0 = %v, want {name:ndots, value:5}", opts[0])
+	}
+	if opts[1][constants.FieldDNSOptionName] != "single-request" || opts[1][constants.FieldDNSOptionValue] != "" {
+		t.Errorf("DNS option 1 = %v, want {name:single-request, value:\"\"}", opts[1])
+	}
+
+	// VM without DNS config
+	vmNoDNS := &kubevirtv1.VirtualMachine{
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{},
+			},
+		},
+	}
+	importerNoDNS := &VMImporter{VirtualMachine: vmNoDNS}
+	if policy := importerNoDNS.DNSPolicy(); policy != "" {
+		t.Errorf("DNSPolicy() empty = %q, want empty", policy)
+	}
+	if dc := importerNoDNS.DNSConfig(); dc != nil {
+		t.Errorf("DNSConfig() empty = %v, want nil", dc)
+	}
+}
+
+func TestConfigMapSecretDiskImport(t *testing.T) {
+	vm := &kubevirtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+		Spec: kubevirtv1.VirtualMachineSpec{
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Devices: kubevirtv1.Devices{
+							Disks: []kubevirtv1.Disk{
+								{
+									Name: "cm-disk",
+									DiskDevice: kubevirtv1.DiskDevice{
+										Disk: &kubevirtv1.DiskTarget{Bus: "virtio"},
+									},
+								},
+								{
+									Name: "sec-disk",
+									DiskDevice: kubevirtv1.DiskDevice{
+										Disk: &kubevirtv1.DiskTarget{Bus: "virtio"},
+									},
+								},
+							},
+						},
+					},
+					Volumes: []kubevirtv1.Volume{
+						{
+							Name: "cm-disk",
+							VolumeSource: kubevirtv1.VolumeSource{
+								ConfigMap: &kubevirtv1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "my-config"},
+								},
+							},
+						},
+						{
+							Name: "sec-disk",
+							VolumeSource: kubevirtv1.VolumeSource{
+								Secret: &kubevirtv1.SecretVolumeSource{
+									SecretName: "my-secret",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	importer := &VMImporter{VirtualMachine: vm}
+	disks, _, err := importer.Volume()
+	if err != nil {
+		t.Fatalf("Volume() error: %v", err)
+	}
+	if len(disks) != 2 {
+		t.Fatalf("Volume() returned %d disks, want 2", len(disks))
+	}
+	if disks[0][constants.FieldDiskConfigMapName] != "my-config" {
+		t.Errorf("disk 0 configmap_name = %v, want my-config", disks[0][constants.FieldDiskConfigMapName])
+	}
+	if disks[1][constants.FieldDiskSecretName] != "my-secret" {
+		t.Errorf("disk 1 secret_name = %v, want my-secret", disks[1][constants.FieldDiskSecretName])
 	}
 }


### PR DESCRIPTION
## Related Issue

harvester/harvester#10160

## Summary

- Add `access_credentials` block to inject SSH public keys (via configDrive, noCloud, or qemuGuestAgent) and user passwords (via qemuGuestAgent) from Kubernetes secrets
- Add `configmap_name` and `secret_name` fields on the `disk` block to mount ConfigMaps and Secrets as disk volumes
- Add `dns_policy` and `dns_config` fields for custom DNS resolution settings (nameservers, search domains, resolver options)

## Files Changed (8)

| File | Change |
|------|--------|
| `pkg/constants/constants_virtualmachine.go` | Field constants for all 4 features |
| `internal/provider/virtualmachine/schema_virtualmachine_access_credential.go` | **New** — access_credentials schema |
| `internal/provider/virtualmachine/schema_virtualmachine_dns.go` | **New** — dns_config schema |
| `internal/provider/virtualmachine/schema_virtualmachine.go` | Register access_credentials, dns_policy, dns_config |
| `internal/provider/virtualmachine/schema_virtualmachine_disk.go` | Add configmap_name, secret_name fields |
| `internal/provider/virtualmachine/resource_virtualmachine_constructor.go` | Parsers + helpers (parseAccessCredential, parseDNSConfig), configmap/secret volume branches, updater clear |
| `pkg/importer/resource_virtualmachine_importer.go` | AccessCredentials(), DNSPolicy(), DNSConfig() importers + configmap/secret Volume() branches |
| `pkg/importer/resource_virtualmachine_importer_test.go` | Unit tests for all 4 features (3 test functions) |

## Test plan

**Unit tests** (6/6 pass):
- `TestAccessCredentialsImport` — SSH public key (qemuGuestAgent with users) + user password import
- `TestDNSImport` — DNS policy + config with nameservers, searches, options (with/without value)
- `TestConfigMapSecretDiskImport` — ConfigMap and Secret volume import

**Functional tests** on Harvester v1.7.1:

Prerequisites created on cluster:
- Secret `test-ssh-keys` (SSH public key)
- Secret `test-user-passwords` (user password)
- ConfigMap `test-cm-disk` (config data)
- Secret `test-sec-disk` (secret data)

| Step | Result |
|------|--------|
| `terraform plan` | Valid plan, all 4 features shown |
| `terraform apply` | VM created in 39s |
| K8s verification: `accessCredentials` | SSH public key (noCloud) + user password (qemuGuestAgent) correctly set |
| K8s verification: `dnsPolicy` | `None` |
| K8s verification: `dnsConfig` | nameservers `[8.8.8.8, 8.8.4.4]`, searches `[example.com, test.local]`, options `[{ndots:5}, {single-request-reopen}]` |
| K8s verification: volumes | `cm-disk` → ConfigMap `test-cm-disk`, `sec-disk` → Secret `test-sec-disk` |
| `terraform plan` (idempotence) | 0 changes on all 4 new features |
| `terraform destroy` | VM destroyed in 49s |