### PR TITLE
feat(image): improve data source display_name lookup with duplicate detection

### DIFF
--- a/docs/data-sources/image.md
+++ b/docs/data-sources/image.md
@@ -13,14 +13,41 @@ description: |-
 ## Example Usage
 
 ```terraform
-data "harvester_image" "ubuntu20" {
-  name      = "ubuntu20"
-  namespace = "harvester-public"
+# Look up an image by its Kubernetes name
+data "harvester_image" "by_name" {
+  name      = "image-nhtf9"
+  namespace = "default"
 }
 
-data "harvester_image" "opensuse154" {
-  namespace    = "harvester-public"
-  display_name = "openSUSE-Leap-15.4.x86_64-NoCloud.qcow2"
+# Look up an image by its display name (user-friendly)
+# Errors if multiple images share the same display name.
+data "harvester_image" "opensuse_tw" {
+  namespace    = "default"
+  display_name = "openSUSE-Tumbleweed-Minimal-VM.x86_64-Cloud.qcow2"
+}
+
+# Use the data source to reference an image in a VM disk
+resource "harvester_virtualmachine" "example" {
+  name      = "example"
+  namespace = "default"
+
+  cpu    = 2
+  memory = "4Gi"
+
+  network_interface {
+    name = "nic-1"
+  }
+
+  disk {
+    name       = "rootdisk"
+    type       = "disk"
+    size       = "20Gi"
+    bus        = "virtio"
+    boot_order = 1
+
+    image       = data.harvester_image.opensuse_tw.id
+    auto_delete = true
+  }
 }
 ```
 

--- a/examples/data-sources/harvester_image/data-source.tf
+++ b/examples/data-sources/harvester_image/data-source.tf
@@ -1,9 +1,36 @@
-data "harvester_image" "ubuntu20" {
-  name      = "ubuntu20"
-  namespace = "harvester-public"
+# Look up an image by its Kubernetes name
+data "harvester_image" "by_name" {
+  name      = "image-nhtf9"
+  namespace = "default"
 }
 
-data "harvester_image" "opensuse154" {
-  namespace    = "harvester-public"
-  display_name = "openSUSE-Leap-15.4.x86_64-NoCloud.qcow2"
+# Look up an image by its display name (user-friendly)
+# Errors if multiple images share the same display name.
+data "harvester_image" "opensuse_tw" {
+  namespace    = "default"
+  display_name = "openSUSE-Tumbleweed-Minimal-VM.x86_64-Cloud.qcow2"
+}
+
+# Use the data source to reference an image in a VM disk
+resource "harvester_virtualmachine" "example" {
+  name      = "example"
+  namespace = "default"
+
+  cpu    = 2
+  memory = "4Gi"
+
+  network_interface {
+    name = "nic-1"
+  }
+
+  disk {
+    name       = "rootdisk"
+    type       = "disk"
+    size       = "20Gi"
+    bus        = "virtio"
+    boot_order = 1
+
+    image       = data.harvester_image.opensuse_tw.id
+    auto_delete = true
+  }
 }

--- a/internal/provider/image/datasource_image.go
+++ b/internal/provider/image/datasource_image.go
@@ -3,14 +3,82 @@ package image
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	harvsterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	harvsterutil "github.com/harvester/harvester/pkg/util"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/harvester/terraform-provider-harvester/internal/config"
+	"github.com/harvester/terraform-provider-harvester/pkg/client"
 	"github.com/harvester/terraform-provider-harvester/pkg/constants"
 )
+
+// isValidLabelValue returns true if the string is a valid Kubernetes label value.
+func isValidLabelValue(v string) bool {
+	return len(validation.IsValidLabelValue(v)) == 0
+}
+
+// imagesMatchingDisplayName returns the images whose spec.displayName equals
+// displayName. The comparison always uses the spec: the imageDisplayName label
+// only mirrors it for display names that are valid label values, and only once
+// the image import succeeded.
+func imagesMatchingDisplayName(items []harvsterv1.VirtualMachineImage, displayName string) []*harvsterv1.VirtualMachineImage {
+	var matches []*harvsterv1.VirtualMachineImage
+	for i := range items {
+		if items[i].Spec.DisplayName == displayName {
+			matches = append(matches, &items[i])
+		}
+	}
+	return matches
+}
+
+func lookupImageByDisplayName(ctx context.Context, c *client.Client, namespace, displayName string) (*harvsterv1.VirtualMachineImage, error) {
+	imageClient := c.HarvesterClient.HarvesterhciV1beta1().VirtualMachineImages(namespace)
+
+	var matches []*harvsterv1.VirtualMachineImage
+	// Fast path: Harvester mirrors display names that are valid label values
+	// into the imageDisplayName label, so the API server can filter for us.
+	if isValidLabelValue(displayName) {
+		images, err := imageClient.List(ctx, metav1.ListOptions{
+			LabelSelector: harvsterutil.LabelImageDisplayName + "=" + displayName,
+		})
+		if err != nil {
+			return nil, err
+		}
+		matches = imagesMatchingDisplayName(images.Items, displayName)
+	}
+	// The label is only set once the image import succeeded (and never for
+	// display names that are not valid label values), so an empty fast path is
+	// not conclusive: fall back to a full list before reporting anything.
+	if len(matches) == 0 {
+		images, err := imageClient.List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+		matches = imagesMatchingDisplayName(images.Items, displayName)
+	}
+
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("cannot find image with display_name %s in namespace %s", displayName, namespace)
+	case 1:
+		return matches[0], nil
+	default:
+		names := make([]string, len(matches))
+		for i, image := range matches {
+			names[i] = image.Name
+		}
+		// Harvester only enforces display name uniqueness through the
+		// imageDisplayName label, so duplicates can exist for display names
+		// that are not valid label values (e.g. containing spaces).
+		return nil, fmt.Errorf("display_name %s matches %d images in namespace %s (%s), use name to select a specific image",
+			displayName, len(matches), namespace, strings.Join(names, ", "))
+	}
+}
 
 func DataSourceImage() *schema.Resource {
 	return &schema.Resource{
@@ -37,16 +105,11 @@ func dataSourceImageRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if displayName != "" {
-		images, err := c.HarvesterClient.HarvesterhciV1beta1().VirtualMachineImages(namespace).List(ctx, metav1.ListOptions{})
+		image, err := lookupImageByDisplayName(ctx, c, namespace, displayName)
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		for i, image := range images.Items {
-			if image.Spec.DisplayName == displayName {
-				return diag.FromErr(resourceImageImport(d, &images.Items[i]))
-			}
-		}
-		return diag.FromErr(fmt.Errorf("can not find image %s in namespace %s", displayName, namespace))
+		return diag.FromErr(resourceImageImport(d, image))
 	}
 
 	return diag.FromErr(fmt.Errorf("must specify image %s or %s", constants.FieldCommonName, constants.FieldImageDisplayName))

--- a/internal/provider/image/datasource_image_test.go
+++ b/internal/provider/image/datasource_image_test.go
@@ -1,0 +1,89 @@
+package image
+
+import (
+	"strings"
+	"testing"
+
+	harvsterv1 "github.com/harvester/harvester/pkg/apis/harvesterhci.io/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func imageWithDisplayName(name, displayName string) harvsterv1.VirtualMachineImage {
+	return harvsterv1.VirtualMachineImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: harvsterv1.VirtualMachineImageSpec{
+			DisplayName: displayName,
+		},
+	}
+}
+
+// TestImagesMatchingDisplayName verifies the matching is driven by
+// spec.displayName only: images are matched regardless of the presence of the
+// imageDisplayName label, and non-matching images are excluded.
+func TestImagesMatchingDisplayName(t *testing.T) {
+	items := []harvsterv1.VirtualMachineImage{
+		imageWithDisplayName("img-a", "openSUSE Tumbleweed Cloud"),
+		imageWithDisplayName("img-b", "sles15-sp7.qcow2"),
+		imageWithDisplayName("img-c", "openSUSE Tumbleweed Cloud"),
+	}
+
+	testcases := []struct {
+		name          string
+		displayName   string
+		expectedNames []string
+	}{
+		{
+			name:          "no match",
+			displayName:   "does-not-exist",
+			expectedNames: nil,
+		},
+		{
+			name:          "single match",
+			displayName:   "sles15-sp7.qcow2",
+			expectedNames: []string{"img-b"},
+		},
+		{
+			name:          "duplicate display names with spaces are all reported",
+			displayName:   "openSUSE Tumbleweed Cloud",
+			expectedNames: []string{"img-a", "img-c"},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			matches := imagesMatchingDisplayName(items, tc.displayName)
+			if len(matches) != len(tc.expectedNames) {
+				t.Fatalf("got %d matches, want %d", len(matches), len(tc.expectedNames))
+			}
+			for i, expected := range tc.expectedNames {
+				if matches[i].Name != expected {
+					t.Errorf("match %d = %q, want %q", i, matches[i].Name, expected)
+				}
+			}
+		})
+	}
+}
+
+// TestIsValidLabelValue pins the classification used to decide between the
+// server-side label fast path and the full list fallback.
+func TestIsValidLabelValue(t *testing.T) {
+	testcases := []struct {
+		value string
+		valid bool
+	}{
+		{"sles15-sp7-minimal-vm.x86_64-cloud-qu2.qcow2", true},
+		{"win2025-core-autounattend", true},
+		{"openSUSE Tumbleweed Cloud", false},
+		{"openSUSE Tumbleweed Cloud (AISCALEIMAGE)", false},
+		{"Rocky Linux 9 GenericCloud", false},
+		{strings.Repeat("a", 64), false},
+		{"", true},
+	}
+	for _, tc := range testcases {
+		if got := isValidLabelValue(tc.value); got != tc.valid {
+			t.Errorf("isValidLabelValue(%q) = %v, want %v", tc.value, got, tc.valid)
+		}
+	}
+}

--- a/internal/provider/image/schema_image.go
+++ b/internal/provider/image/schema_image.go
@@ -111,5 +111,9 @@ func DataSourceSchema() map[string]*schema.Schema {
 	s[constants.FieldCommonName].Optional = true
 	s[constants.FieldImageDisplayName].Computed = false
 	s[constants.FieldImageDisplayName].Optional = true
+	// Exactly one lookup key: silently preferring one of the two would hide
+	// configuration mistakes, and providing neither cannot resolve an image.
+	s[constants.FieldCommonName].ExactlyOneOf = []string{constants.FieldCommonName, constants.FieldImageDisplayName}
+	s[constants.FieldImageDisplayName].ExactlyOneOf = []string{constants.FieldCommonName, constants.FieldImageDisplayName}
 	return s
 }


### PR DESCRIPTION
## Summary

Looking up an image by `display_name` in the `harvester_image` data source now reports every match instead of silently returning the first one, and fails with the list of image names when several images share the same display name. Harvester only enforces display name uniqueness through the `imageDisplayName` label, which is not set for display names that are not valid label values (for example ones containing spaces), so duplicates can exist for those.

When the display name is a valid label value, the lookup filters server-side on that label, as suggested in review. An empty result then falls back to a full list before reporting anything, because the label is not always present (it is not set for display names that are not valid label values, and on older versions it is only added by a controller once the image import succeeded), so a still-importing or legacy image would otherwise be reported as missing.

`name` and `display_name` are now mutually exclusive in the data source schema (`ExactlyOneOf`), instead of `display_name` being silently ignored when both were set.

Resolves: harvester/harvester#10163

## Recommended pattern

```hcl
data "harvester_image" "sles15" {
  display_name = "sles15-sp7-minimal-vm.x86_64-cloud-qu2.qcow2"
  namespace    = "default"
}

resource "harvester_virtualmachine" "vm" {
  disk {
    image = data.harvester_image.sles15.id
  }
}
```

The data source resolves the display name to the stable `namespace/name` id, so the disk reference does not change between plans.

## Test plan

Unit tests cover the matching helper (no match, single match, duplicates) and the label-value classification that selects the fast path.

Functional tests on Harvester v1.8.2:

- lookup through the server-side label fast path, resolves to the expected image id
- lookup of a display name containing spaces, which has no label, resolves through the client-side fallback
- lookup of a label-valid display name whose label was removed from the object, still resolves through the fallback (this is the case that previously reported the image as missing)
- `name` and `display_name` set together, and neither set, are both rejected at plan time with a clear error
- duplicate detection is covered by unit tests: on v1.8.2 a second image with the same display name can no longer be created, since a display name that is not a valid label value is now rejected at admission, but such images still exist on clusters upgraded from earlier versions
