### PR TITLE
fix(schema): clear validation rules for data source schema wrap

### DIFF
--- a/internal/util/schema.go
+++ b/internal/util/schema.go
@@ -88,6 +88,9 @@ func DataSourceSchemaWrap(s map[string]*schema.Schema) map[string]*schema.Schema
 		v.Required = false
 		v.ValidateFunc = nil
 		v.ConflictsWith = nil
+		v.AtLeastOneOf = nil
+		v.ExactlyOneOf = nil
+		v.RequiredWith = nil
 		v.MinItems = 0
 		v.MaxItems = 0
 	}

--- a/internal/util/schema.go
+++ b/internal/util/schema.go
@@ -76,8 +76,10 @@ func DataSourceSchemaWrap(s map[string]*schema.Schema) map[string]*schema.Schema
 		}
 		if v.Elem != nil {
 			switch elem := v.Elem.(type) {
-			case schema.Resource:
-				v.Elem = DataSourceSchemaWrap(elem.Schema)
+			case *schema.Resource:
+				v.Elem = &schema.Resource{
+					Schema: DataSourceSchemaWrap(elem.Schema),
+				}
 			}
 		}
 		v.ForceNew = false


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

This fixes an InternalValidate error causing by data sources like harvester_schedule_backup that have AtLeastOneOf or similar constraints on computed fields. Since data source fields are computed-only, they cannot have these configurable attributes.

```
> terraform apply
╷
│ Error: InternalValidate
│ 
│   with provider["registry.terraform.io/harvester/harvester"],
│   on providers.tf line 10, in provider "harvester":
│   10: provider "harvester" {
│ 
│ Internal validation of the provider failed! This is always a bug
│ with the provider itself, and not a user issue. Please report
│ this bug:
│ 
│ data source harvester_schedule_backup: volume_name: AtLeastOneOf is for configurable attributes,there's nothing to configure on computed-only field
```

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

The provider uses the `DataSourceSchemaWrap` utility function (in `internal/util/schema.go`) to dynamically convert resource schemas into read-only data source schemas by setting all fields to `Computed = true`. 
This PR updates `DataSourceSchemaWrap` to correctly clear the `AtLeastOneOf`, `ExactlyOneOf`, and `RequiredWith` validation rules during this conversion. This prevents the Terraform SDK from crashing while preserving the original validation rules for the actual Resources.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/10181

#### Test plan:
<!-- Describe the test plan by steps. -->

Can correctly execute `terraform plan`

```
❯ tail -n +1 main.tf versions.tf
==> main.tf <==
resource "harvester_virtualmachine" "fedora" {
  name                 = "fedora"
  namespace            = "default"

  cpu    = 1
  memory = "2Gi"

  efi         = true
  secure_boot = true

  hostname        = "fedora"

  network_interface {
    name           = "nic-1"
    wait_for_lease = true
  }

  disk {
    name       = "rootdisk"
    type       = "disk"
    bus        = "virtio"
    boot_order = 1

    container_image_name = "kubevirt/fedora-cloud-container-disk-demo:v0.35.0"
  }

  disk {
    name       = "cd1"
    type       = "cd-rom"
    bus        = "sata"
    boot_order = 2
    # hot_plug   = true
    #
    # image       = "default/image-lz57s"
    # auto_delete = true
  }

}

==> versions.tf <==
terraform {
  required_providers {
    harvester = {
      source  = "harvester/harvester"
      version = "0.0.0-dev"
    }
  }
}

provider "harvester" {
  kubeconfig = "./local.yaml"
}

```


```
❯ terraform init
Initializing the backend...
Initializing provider plugins...
- Finding harvester/harvester versions matching "0.0.0-dev"...
- Installing harvester/harvester v0.0.0-dev...
- Installed harvester/harvester v0.0.0-dev (unauthenticated)
Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

╷
│ Warning: Incomplete lock file information for providers
│
│ Due to your customized provider installation methods, Terraform was forced to calculate lock file checksums locally for the following providers:
│   - harvester/harvester
│
│ The current .terraform.lock.hcl file only includes checksums for linux_amd64, so Terraform running on another platform will fail to install these providers.
│
│ To calculate additional checksums for another platform, run:
│   terraform providers lock -platform=linux_amd64
│ (where linux_amd64 is the platform to generate)
╵
Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.

❯ terraform plan

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # harvester_virtualmachine.fedora will be created
  + resource "harvester_virtualmachine" "fedora" {
      + cpu                     = 1
      + cpu_pinning             = false
      + create_initial_snapshot = false
      + efi                     = true
      + hostname                = "fedora"
      + id                      = (known after apply)
      + isolate_emulator_thread = false
      + machine_type            = (known after apply)
      + memory                  = "2Gi"
      + message                 = (known after apply)
      + name                    = "fedora"
      + namespace               = "default"
      + node_name               = (known after apply)
      + restart_after_update    = false
      + run_strategy            = "RerunOnFailure"
      + secure_boot             = true
      + state                   = (known after apply)

      + disk {
          + access_mode          = (known after apply)
          + auto_delete          = (known after apply)
          + boot_order           = 1
          + bus                  = "virtio"
          + container_image_name = "kubevirt/fedora-cloud-container-disk-demo:v0.35.0"
          + hot_plug             = (known after apply)
          + name                 = "rootdisk"
          + storage_class_name   = (known after apply)
          + type                 = "disk"
          + volume_mode          = (known after apply)
          + volume_name          = (known after apply)
        }
      + disk {
          + access_mode        = (known after apply)
          + auto_delete        = (known after apply)
          + boot_order         = 2
          + bus                = "sata"
          + hot_plug           = (known after apply)
          + name               = "cd1"
          + storage_class_name = (known after apply)
          + type               = "cd-rom"
          + volume_mode        = (known after apply)
          + volume_name        = (known after apply)
        }

      + network_interface {
          + boot_order     = 0
          + interface_name = (known after apply)
          + ip_address     = (known after apply)
          + mac_address    = (known after apply)
          + model          = "virtio"
          + name           = "nic-1"
          + type           = (known after apply)
          + wait_for_lease = true
        }

      + requests (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.

```

#### Additional documentation or context
