### PR TITLE
Expose disk cache mode

### DIFF
--- a/docs/data-sources/virtualmachine.md
+++ b/docs/data-sources/virtualmachine.md
@@ -96,6 +96,7 @@ Read-Only:
 - `auto_delete` (Boolean)
 - `boot_order` (Number)
 - `bus` (String)
+- `cache_mode` (String)
 - `container_image_name` (String)
 - `existing_volume_name` (String)
 - `hot_plug` (Boolean)

--- a/docs/resources/virtualmachine.md
+++ b/docs/resources/virtualmachine.md
@@ -247,6 +247,7 @@ Optional:
 - `auto_delete` (Boolean)
 - `boot_order` (Number)
 - `bus` (String)
+- `cache_mode` (String)
 - `container_image_name` (String)
 - `existing_volume_name` (String)
 - `hot_plug` (Boolean)

--- a/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
+++ b/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -258,9 +257,6 @@ func (c *Constructor) Setup() util.Processors {
 				vmBuilder.Disk(diskName, diskBus, isCDRom, uint(bootOrder)) // nolint: gosec
 				if diskCacheMode != "" {
 					mode := kubevirtv1.DriverCache(diskCacheMode)
-					if !slices.Contains([]kubevirtv1.DriverCache{kubevirtv1.CacheNone, kubevirtv1.CacheWriteThrough, kubevirtv1.CacheWriteBack}, mode) {
-						return fmt.Errorf("invalid disk cache mode for disk %s: %v", diskName, mode)
-					}
 					vmBuilder.DiskCacheMode(diskName, mode)
 					if vmBuilder.Error != nil {
 						return vmBuilder.Error

--- a/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
+++ b/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -235,6 +236,7 @@ func (c *Constructor) Setup() util.Processors {
 				diskName := r[constants.FieldDiskName].(string)
 				diskSize := r[constants.FieldDiskSize].(string)
 				diskBus := r[constants.FieldDiskBus].(string)
+				diskCacheMode := r[constants.FieldDiskCacheMode].(string)
 				diskType := r[constants.FieldDiskType].(string)
 				bootOrder := r[constants.FieldDiskBootOrder].(int)
 				imageNamespacedName := r[constants.FieldVolumeImage].(string)
@@ -254,6 +256,17 @@ func (c *Constructor) Setup() util.Processors {
 				}
 
 				vmBuilder.Disk(diskName, diskBus, isCDRom, uint(bootOrder)) // nolint: gosec
+				if diskCacheMode != "" {
+					mode := kubevirtv1.DriverCache(diskCacheMode)
+					if !slices.Contains([]kubevirtv1.DriverCache{kubevirtv1.CacheNone, kubevirtv1.CacheWriteThrough, kubevirtv1.CacheWriteBack}, mode) {
+						return fmt.Errorf("invalid disk cache mode for disk %s: %v", diskName, mode)
+					}
+					vmBuilder.DiskCacheMode(diskName, mode)
+					if vmBuilder.Error != nil {
+						return vmBuilder.Error
+					}
+				}
+
 				if existingVolumeName != "" {
 					vmBuilder.ExistingPVCVolume(diskName, existingVolumeName, hotPlug)
 				} else if containerImageName != "" {

--- a/internal/provider/virtualmachine/schema_virtualmachine_disk.go
+++ b/internal/provider/virtualmachine/schema_virtualmachine_disk.go
@@ -39,6 +39,17 @@ func resourceDiskSchema() map[string]*schema.Schema {
 				"",
 			}, false),
 		},
+		constants.FieldDiskCacheMode: {
+			Type:     schema.TypeString,
+			Optional: true,
+			Default:  "",
+			ValidateFunc: validation.StringInSlice([]string{
+				constants.DiskCacheModeNone,
+				constants.DiskCacheModeWriteBack,
+				constants.DiskCacheModeWriteThrough,
+				"",
+			}, false),
+		},
 		constants.FieldDiskBootOrder: {
 			Type:         schema.TypeInt,
 			Optional:     true,

--- a/internal/tests/resource_virtualmachine_test.go
+++ b/internal/tests/resource_virtualmachine_test.go
@@ -436,6 +436,59 @@ resource harvester_virtualmachine "disk_test" {
 	})
 }
 
+func TestAccVirtualMachine_disk_cache_mode(t *testing.T) {
+	var (
+		testAccVMName         = "disk-cache-mode-test"
+		testAccVMResourceName = constants.ResourceTypeVirtualMachine + "." + testAccVMName
+		testAccCacheMode      = constants.DiskCacheModeWriteBack
+		ctx                   = context.Background()
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVirtualMachineDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource harvester_virtualmachine "%s" {
+	name = "%s"
+	namespace = "default"
+
+  cpu = 1
+  memory = "1Gi"
+
+  run_strategy = "RerunOnFailure"
+  machine_type = "q35"
+
+  network_interface {
+    name         = "default"
+  }
+
+  disk {
+    name       = "rootdisk"
+    type       = "disk"
+    bus        = "virtio"
+		cache_mode = "%s"
+    boot_order = 1
+		container_image_name = "kubevirt/fedora-cloud-container-disk-demo:v0.35.0"
+  }
+}
+`,
+					testAccVMName,
+					testAccVMName,
+					testAccCacheMode,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testAccVMResourceName, constants.FieldCommonName, testAccVMName),
+					resource.TestCheckResourceAttr(testAccVMResourceName, constants.FieldVirtualMachineDisk+".#", "1"),
+					resource.TestCheckResourceAttr(testAccVMResourceName, constants.FieldVirtualMachineDisk+".0."+constants.FieldDiskCacheMode, testAccCacheMode),
+				),
+			},
+		},
+	})
+}
+
 func TestAccVirtualMachine_labels(t *testing.T) {
 	var (
 		vm             *kubevirtv1.VirtualMachine

--- a/pkg/constants/constants_virtualmachine.go
+++ b/pkg/constants/constants_virtualmachine.go
@@ -67,6 +67,7 @@ const (
 	FieldDiskType               = "type"
 	FieldDiskSize               = "size"
 	FieldDiskBus                = "bus"
+	FieldDiskCacheMode          = "cache_mode"
 	FieldDiskBootOrder          = "boot_order"
 	FieldDiskExistingVolumeName = "existing_volume_name"
 	FieldDiskContainerImageName = "container_image_name"
@@ -89,4 +90,10 @@ const (
 
 const (
 	LabelSSHUsername = "ssh-user"
+)
+
+const (
+	DiskCacheModeNone         = "none"
+	DiskCacheModeWriteBack    = "writeback"
+	DiskCacheModeWriteThrough = "writethrough"
 )

--- a/pkg/importer/resource_virtualmachine_importer.go
+++ b/pkg/importer/resource_virtualmachine_importer.go
@@ -312,10 +312,12 @@ func (v *VMImporter) Volume() ([]map[string]interface{}, []map[string]interface{
 		} else {
 			return nil, nil, fmt.Errorf("unsupported volume type found on volume %s. ", disk.Name)
 		}
+
 		diskState[constants.FieldDiskName] = disk.Name
 		diskState[constants.FieldDiskBootOrder] = disk.BootOrder
 		diskState[constants.FieldDiskType] = diskType
 		diskState[constants.FieldDiskBus] = diskBus
+		diskState[constants.FieldDiskCacheMode] = disk.Cache
 
 		if volume, hasVolume := volumesMap[disk.Name]; hasVolume {
 			if volume.CloudInitNoCloud != nil || volume.CloudInitConfigDrive != nil {


### PR DESCRIPTION
Add attribute to VM disks, which lets users specify the cache mode to use for that particular disk.
KubeVirt supports three different cache modes for VM disks: "none", "writethrough" or "writeback". They have different implications for performance and data consistency in the event of VM crashes. By exposing this setting to users, VM disks can be optimized to suit particular workloads.

related-to: harvester/harvester#9383

## Problem:

There is no way to configure the cache mode of a VM disk with the Terraform provider

## Solution:

Expose the cache mode setting in the Terraform provider

## Related Issue(s):

https://github.com/harvester/harvester/issues/9383

## Test plan:

Acceptance tests are included.

#### Test Case 1

Creating a VM with customized disk cache mode

```
resource "harvester_virtualmachine" "test" {
  name                 = "test"
  namespace            = "default"
  restart_after_update = true

  description = "test disk cache mode"
  cpu    = 2
  memory = "4Gi"

  run_strategy    = "RerunOnFailure"
  hostname        = "opensuse"
  reserved_memory = "100Mi"
  machine_type    = "q35"

  network_interface {
    name           = "default"
    wait_for_lease = true
  }

  disk {
    name       = "rootdisk"
    type       = "disk"
    size       = "10Gi"
    bus        = "virtio"
    boot_order = 1

    image       = harvester_image.leap.id
    auto_delete = true
    cache_mode  = "writeback"
  }

  cloudinit {
    user_data    = <<-EOF
      #cloud-config
      user: opensuse
      password: foobar
      chpasswd:
        expire: false
      ssh_pwauth: true
      package_update: true
      packages:
        - qemu-guest-agent
      runcmd:
        - - systemctl
          - enable
          - '--now'
          - qemu-guest-agent
      EOF
  }
}
```

#### Test Case 2

Importing a VM resource into Terraform state

```
$ terraform import harvester_virtualmachine.test default/test
```

The Terraform state is expected to contain the correct disk cache mode information:
```
[...]
    {
      "mode": "managed",
      "type": "harvester_virtualmachine",
      "name": "test",
      "provider": "provider[\"terraform.local/local/harvester\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "cloudinit": [
              {
                "network_data": "",
                "network_data_base64": "",
                "network_data_secret_name": "",
                "type": "noCloud",
                "user_data": "#cloud-config\nuser: opensuse\npassword: foobar\nchpasswd:\n  expire: false\nssh_pwauth: true\npackage_update: true\npackages:\n  - qemu-guest-agent\nruncmd:\n  - - systemctl\n    - enable\n    - '--now'\n    - qemu-guest-agent\n",
                "user_data_base64": "",
                "user_data_secret_name": ""
              }
            ],
            "cpu": 2,
            "cpu_model": "",
            "cpu_pinning": false,
            "create_initial_snapshot": null,
            "description": "test disk cache mode",
            "disk": [
              {
                "access_mode": "ReadWriteMany",
                "auto_delete": true,
                "boot_order": 1,
                "bus": "virtio",
                "cache_mode": "writeback",
                "container_image_name": "",
                "existing_volume_name": "",
                "hot_plug": false,
                "image": "default/opensuse-leap",
                "name": "rootdisk",
                "size": "10Gi",
                "storage_class_name": "lh-7e88369f-c505-41a1-863f-71a9f7d8f8e3",
                "type": "disk",
                "volume_mode": "Block",
                "volume_name": "test-rootdisk-rgr9p"
              },
              {
                "access_mode": "",
                "auto_delete": false,
                "boot_order": 0,
                "bus": "virtio",
                "cache_mode": "",
                "container_image_name": "",
                "existing_volume_name": "",
                "hot_plug": false,
                "image": "",
                "name": "cloudinitdisk",
                "size": "",
                "storage_class_name": "",
                "type": "disk",
                "volume_mode": "",
                "volume_name": ""
              }
            ],
            "efi": false,
            "hostname": "opensuse",
            "id": "default/test",
            "input": [],
            "isolate_emulator_thread": false,
            "labels": {},
            "machine_type": "q35",
            "memory": "4Gi",
            "message": null,
            "name": "test",
            "namespace": "default",
            "network_interface": [
              {
                "boot_order": 0,
                "interface_name": "eth0",
                "ip_address": "10.52.0.85",
                "mac_address": "a2:4c:c2:36:48:e3",
                "model": "virtio",
                "name": "default",
                "network_name": "",
                "type": "masquerade",
                "wait_for_lease": true
              }
            ],
            "node_name": "harv0",
            "node_selector": {},
            "requests": [
              {
                "cpu": "200m",
                "memory": "2730Mi"
              }
            ],
            "reserved_memory": "100Mi",
            "restart_after_update": null,
            "run_strategy": "RerunOnFailure",
            "secure_boot": false,
            "ssh_keys": [],
            "start": null,
            "state": "Ready",
            "tags": {},
            "timeouts": null,
            "tpm": []
          },
          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAsImRlZmF1bHQiOjEyMDAwMDAwMDAwMCwiZGVsZXRlIjozMDAwMDAwMDAwMDAsInJlYWQiOjEyMDAwMDAwMDAwMCwidXBkYXRlIjoxMjAwMDAwMDAwMDB9LCJzY2hlbWFfdmVyc2lvbiI6IjAifQ=="
        }
      ]
    },
[...]
```

## Additional documentation or context:

https://kubevirt.io/user-guide/storage/disks_and_volumes/#disk-device-cache