### PR TITLE
VM State: Fix VM state for network interfaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/harvester/harvester-load-balancer v1.8.0
 	github.com/harvester/harvester-network-controller v1.8.0
 	github.com/harvester/pcidevices v1.8.0
+	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/terraform-plugin-docs v0.25.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
@@ -36,6 +37,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/rancher/wrangler/v3 v3.2.4
 	github.com/sirupsen/logrus v1.9.4
+	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.34.1
 	k8s.io/apimachinery v0.34.1
@@ -100,7 +102,6 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-cty v1.5.0 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.7.0 // indirect
@@ -152,6 +153,7 @@ require (
 	github.com/openshift/custom-resource-status v1.1.2 // indirect
 	github.com/ovn-org/libovsdb v0.7.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.82.0 // indirect

--- a/pkg/importer/resource_cloudinitsecret_importer_test.go
+++ b/pkg/importer/resource_cloudinitsecret_importer_test.go
@@ -1,0 +1,43 @@
+package importer
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	"github.com/harvester/terraform-provider-harvester/pkg/constants"
+)
+
+func TestStateRunningNetworkInterfaceNoIP(t *testing.T) {
+	// Ensure that of `wait_for_lease` is set on a network interface, the state isn't reported as
+	// `ready` as long as there is no IP address
+	oldInstanceUID := "oldUid"
+	networkInterfaces := []map[string]any{
+		{
+			constants.FieldNetworkInterfaceWaitForLease: true,
+		},
+	}
+	vmi := kubevirtv1.VirtualMachineInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: "newUid",
+		},
+		Status: kubevirtv1.VirtualMachineInstanceStatus{
+			Phase: "Running",
+		},
+	}
+
+	vmImporter := NewVMImporter(nil, &vmi)
+	state := vmImporter.State(networkInterfaces, oldInstanceUID)
+	assert.Equal(t, state, constants.StateVirtualMachineRunning, "IP address not set results in state running")
+
+	networkInterfaces[0][constants.FieldNetworkInterfaceIPAddress] = ""
+	state = vmImporter.State(networkInterfaces, oldInstanceUID)
+	assert.Equal(t, state, constants.StateVirtualMachineRunning, "IP address set to empty string results in state running")
+
+	networkInterfaces[0][constants.FieldNetworkInterfaceIPAddress] = "123.123.123.123"
+	state = vmImporter.State(networkInterfaces, oldInstanceUID)
+	assert.Equal(t, state, constants.StateCommonReady, "IP address set to non-empty string results in state ready")
+}

--- a/pkg/importer/resource_virtualmachine_importer.go
+++ b/pkg/importer/resource_virtualmachine_importer.go
@@ -357,8 +357,11 @@ func (v *VMImporter) State(networkInterfaces []map[string]interface{}, oldInstan
 		if string(v.VirtualMachineInstance.UID) == oldInstanceUID {
 			return constants.StateVirtualMachineRunning
 		}
+
 		for _, networkInterface := range networkInterfaces {
-			if networkInterface[constants.FieldNetworkInterfaceWaitForLease].(bool) && networkInterface[constants.FieldNetworkInterfaceIPAddress] == "" {
+			wait_for_lease := networkInterface[constants.FieldNetworkInterfaceWaitForLease].(bool)
+			ip_string, has_ip_string := networkInterface[constants.FieldNetworkInterfaceIPAddress].(string)
+			if wait_for_lease && (!has_ip_string || ip_string == "") {
 				return constants.StateVirtualMachineRunning
 			}
 		}


### PR DESCRIPTION
Fix VM state for network interfaces with wait_for_lease enabled. If wait_for_lease is enabled for an interface, the VM can not be marked ready before that interface has received an IP address. However, IP addresses may not be assigned immediately as link-local addresses are ignored.
This means that the State() function needs to account for the possibility that an interface doesn't have an IP address at all - not even an empty string assigned.

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:

If a network interface has `wait_for_lease` enabled, and the IP address isn't assigned quickly enough, the state import accidentally marks the VM as ready.

Marking the VM as ready too early is a problem e.g. when using a remote-exec provisioner, since it relies on being able to establish a network connection.

#### Solution:

Account for network interfaces, which don't have any IP address assigned at all.

#### Related Issue(s):

https://github.com/harvester/harvester/issues/11357

#### Test plan:

```
resource "harvester_virtualmachine" "testvm" {
  provisioner "remote-exec" {
    inline = [
      "echo 'Waiting for cloud-init to complete...'",
      "cloud-init status --wait > /dev/null",
      "echo 'Completed cloud-init!'",
    ]

    connection {
      type        = "ssh"
      host        = self.network_interface[0].ip_address
      user        = var.ssh_user
      certificate = var.ssh_pub_key[0]
      agent       = true
      script_path = "/tmp/user-data-check.sh"
    }
  }

  network_interface {
    name         = "nic-1"
    network_name = data.harvester_network.vm_network.id
    wait_for_lease = true
  }

  cloudinit  {
    user_data_secret_name = harvester_cloudinit_secret.bootstrap.name
    network_data_secret_name = harvester_cloudinit_secret.bootstrap.name
  }

  timeouts {
    create = "10m"
  }
}
```

#### Additional documentation or context

https://suse.slack.com/archives/C02CN3TT61M/p1785948849015539