### PR TITLE
fix: avoid apt cache lock in multi-arch builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,10 @@ ARG TERRAFORM_SUM_arm64
 ARG TARGETPLATFORM
 ENV GOTOOLCHAIN=auto
 
-RUN --mount=type=cache,target=/var/lib/apt/lists apt-get update -qq \
+RUN apt-get update -qq \
  && apt-get install -y --no-install-recommends \
-  unzip
+  unzip \
+ && rm -rf /var/lib/apt/lists/*
 
 ENV ARCH=${TARGETPLATFORM#linux/}
 RUN curl -sfL -o /tmp/terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${ARCH}.zip" \


### PR DESCRIPTION
https://github.com/harvester/terraform-provider-harvester/actions/runs/32707129411/job/97374592422
```
0.073 E: Could not get lock /var/lib/apt/lists/lock. It is held by process 0
0.074 E: Unable to lock directory /var/lib/apt/lists/
```

looks like this happened because the publish job builds a multi-platform image: `platforms: linux/amd64,linux/arm64`. So Buildx runs the buildenv stage for amd64 and arm64 in parallel. Both builds hit this Dockerfile line:
```
RUN --mount=type=cache,target=/var/lib/apt/lists apt-get update -qq \
 && apt-get install -y --no-install-recommends \
  unzip
```

That cache mount is shared by default. apt-get update needs an exclusive lock under /var/lib/apt/lists, so one platform grabs the lock and the other fails with: `Could not get lock /var/lib/apt/lists/lock`. The lock error is fixed by removing the shared cache mount.