### PR TITLE
chore: bump go to 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG MK_GOLANGCI_LINT_IMAGE=golangci/golangci-lint:v2.8.0-alpine@sha256:1194f3bfcbaeeb92d8d159fdfbe2a79d18ec0a222d9d984b1438906bca416b51
+ARG MK_GOLANGCI_LINT_IMAGE=golangci/golangci-lint:v2.12.2-alpine@sha256:91b27804074a0bacea298707f016911e60cf0cdbc6c7bf5ccacb5f0606d18d60
 ARG MK_PACKAGE_BASE=registry.suse.com/bci/bci-base:16.1
 ARG MK_REPO=github.com/harvester/terraform-provider-harvester
 ARG MK_REPO_ID=default
@@ -8,17 +8,17 @@ ARG TERRAFORM_SUM_amd64=e079db1a8945e39b1f8ba4e513946b3ab9f32bd5a2bdf19b9b186d22
 ARG TERRAFORM_SUM_arm64=b38f5db944ac4942f11ceea465a91e365b0636febd9998c110fbbe95d61c3b26
 FROM ${MK_GOLANGCI_LINT_IMAGE} AS golangci-lint
 
-FROM golang:1.25-bookworm AS buildenv
+FROM registry.suse.com/bci/golang:1.26 AS buildenv
 ARG TERRAFORM_VERSION
 ARG TERRAFORM_SUM_amd64
 ARG TERRAFORM_SUM_arm64
 ARG TARGETPLATFORM
 ENV GOTOOLCHAIN=auto
 
-RUN apt-get update -qq \
- && apt-get install -y --no-install-recommends \
-  unzip \
- && rm -rf /var/lib/apt/lists/*
+RUN zypper -n rm container-suseconnect \
+ && zypper -n install git curl unzip \
+ && zypper -n clean -a \
+ && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/*
 
 ENV ARCH=${TARGETPLATFORM#linux/}
 RUN curl -sfL -o /tmp/terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${ARCH}.zip" \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/terraform-provider-harvester
 
-go 1.25.8
+go 1.26
 
 replace (
 	github.com/google/gnostic-models => github.com/google/gnostic-models v0.6.9

--- a/internal/provider/bootstrap/resource_bootstrap.go
+++ b/internal/provider/bootstrap/resource_bootstrap.go
@@ -22,6 +22,7 @@ const (
 	bootstrapDefaultUser        = "admin"
 	bootstrapDefaultTTL         = 60000
 	bootstrapDefaultSessionDesc = "Terraform bootstrap admin session"
+	authorizationHeader         = "Authorization"
 )
 
 type loginRequestPayload struct {
@@ -94,7 +95,7 @@ func resourceBootstrapCreate(ctx context.Context, d *schema.ResourceData, meta i
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("failed to marshal change password data: %v", err))
 		}
-		changePasswordResp, err := util.DoPost(changePasswordURL, string(changePasswordData), "", true, map[string]string{"Authorization": fmt.Sprintf("Bearer %s", token)})
+		changePasswordResp, err := util.DoPost(changePasswordURL, string(changePasswordData), "", true, map[string]string{authorizationHeader: fmt.Sprintf("Bearer %s", token)})
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -106,7 +107,7 @@ func resourceBootstrapCreate(ctx context.Context, d *schema.ResourceData, meta i
 	// get kubeconfig
 	log.Printf("Doing generate kubeconfig")
 	genKubeConfigURL := fmt.Sprintf("%s/%s", apiURL, "v1/management.cattle.io.clusters/local?action=generateKubeconfig")
-	genKubeConfigResp, err := util.DoPost(genKubeConfigURL, "", "", true, map[string]string{"Authorization": fmt.Sprintf("Bearer %s", token)})
+	genKubeConfigResp, err := util.DoPost(genKubeConfigURL, "", "", true, map[string]string{authorizationHeader: fmt.Sprintf("Bearer %s", token)})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -157,7 +158,7 @@ func resourceBootstrapRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	log.Printf("Doing generate kubeconfig")
 	genKubeConfigURL := fmt.Sprintf("%s/%s", apiURL, "v1/management.cattle.io.clusters/local?action=generateKubeconfig")
-	genKubeConfigResp, err := util.DoPost(genKubeConfigURL, "", "", true, map[string]string{"Authorization": fmt.Sprintf("Bearer %s", token)})
+	genKubeConfigResp, err := util.DoPost(genKubeConfigURL, "", "", true, map[string]string{authorizationHeader: fmt.Sprintf("Bearer %s", token)})
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/pkg/importer/resource_virtualmachine_importer_test.go
+++ b/pkg/importer/resource_virtualmachine_importer_test.go
@@ -20,6 +20,16 @@ func TestNetworkInterface(t *testing.T) {
 		expectError error
 	}
 
+	const (
+		networkName0   = "net0"
+		networkName1   = "net1"
+		networkName2   = "net2"
+		interfaceName0 = "eth0"
+		linkLocalIPv60 = "fe80::21f:bcff:fe13:405/64"
+		ipv4Address0   = "192.168.178.64/24"
+		ipv4Address1   = "192.168.180.64/24"
+	)
+
 	properties := []string{
 		constants.FieldNetworkInterfaceName,
 		constants.FieldNetworkInterfaceType,
@@ -114,7 +124,7 @@ func TestNetworkInterface(t *testing.T) {
 									Devices: kubevirtv1.Devices{
 										Interfaces: []kubevirtv1.Interface{
 											{
-												Name: "net0",
+												Name: networkName0,
 												InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
 													Bridge: &kubevirtv1.InterfaceBridge{},
 												},
@@ -131,9 +141,9 @@ func TestNetworkInterface(t *testing.T) {
 					Status: kubevirtv1.VirtualMachineInstanceStatus{
 						Interfaces: []kubevirtv1.VirtualMachineInstanceNetworkInterface{
 							{
-								Name:          "net0",
-								InterfaceName: "eth0",
-								IPs:           []string{"169.254.10.140/24", "fe80::21f:bcff:fe13:405/64"},
+								Name:          networkName0,
+								InterfaceName: interfaceName0,
+								IPs:           []string{"169.254.10.140/24", linkLocalIPv60},
 							},
 						},
 					},
@@ -141,7 +151,7 @@ func TestNetworkInterface(t *testing.T) {
 			},
 			expectation: []map[string]interface{}{
 				{
-					constants.FieldNetworkInterfaceName:         "net0",
+					constants.FieldNetworkInterfaceName:         networkName0,
 					constants.FieldNetworkInterfaceType:         builder.NetworkInterfaceTypeBridge,
 					constants.FieldNetworkInterfaceModel:        "",
 					constants.FieldNetworkInterfaceMACAddress:   "",
@@ -167,7 +177,7 @@ func TestNetworkInterface(t *testing.T) {
 									Devices: kubevirtv1.Devices{
 										Interfaces: []kubevirtv1.Interface{
 											{
-												Name: "net0",
+												Name: networkName0,
 												InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
 													Bridge: &kubevirtv1.InterfaceBridge{},
 												},
@@ -184,9 +194,9 @@ func TestNetworkInterface(t *testing.T) {
 					Status: kubevirtv1.VirtualMachineInstanceStatus{
 						Interfaces: []kubevirtv1.VirtualMachineInstanceNetworkInterface{
 							{
-								Name:          "net0",
-								InterfaceName: "eth0",
-								IPs:           []string{"192.168.178.64/24", "fe80::21f:bcff:fe13:405/64"},
+								Name:          networkName0,
+								InterfaceName: interfaceName0,
+								IPs:           []string{ipv4Address0, linkLocalIPv60},
 							},
 						},
 					},
@@ -194,15 +204,15 @@ func TestNetworkInterface(t *testing.T) {
 			},
 			expectation: []map[string]interface{}{
 				{
-					constants.FieldNetworkInterfaceName:          "net0",
+					constants.FieldNetworkInterfaceName:          networkName0,
 					constants.FieldNetworkInterfaceType:          builder.NetworkInterfaceTypeBridge,
 					constants.FieldNetworkInterfaceModel:         "",
 					constants.FieldNetworkInterfaceMACAddress:    "",
 					constants.FieldNetworkInterfaceNetworkName:   "",
 					constants.FieldNetworkInterfaceBootOrder:     &[]uint{1}[0],
 					constants.FieldNetworkInterfaceWaitForLease:  false,
-					constants.FieldNetworkInterfaceIPAddress:     "192.168.178.64/24",
-					constants.FieldNetworkInterfaceInterfaceName: "eth0",
+					constants.FieldNetworkInterfaceIPAddress:     ipv4Address0,
+					constants.FieldNetworkInterfaceInterfaceName: interfaceName0,
 				},
 			},
 			expectError: nil,
@@ -222,21 +232,21 @@ func TestNetworkInterface(t *testing.T) {
 									Devices: kubevirtv1.Devices{
 										Interfaces: []kubevirtv1.Interface{
 											{
-												Name: "net0",
+												Name: networkName0,
 												InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
 													Bridge: &kubevirtv1.InterfaceBridge{},
 												},
 												BootOrder: &[]uint{1}[0],
 											},
 											{
-												Name: "net1",
+												Name: networkName1,
 												InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
 													Bridge: &kubevirtv1.InterfaceBridge{},
 												},
 												BootOrder: &[]uint{2}[0],
 											},
 											{
-												Name: "net2",
+												Name: networkName2,
 												InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
 													Bridge: &kubevirtv1.InterfaceBridge{},
 												},
@@ -253,19 +263,19 @@ func TestNetworkInterface(t *testing.T) {
 					Status: kubevirtv1.VirtualMachineInstanceStatus{
 						Interfaces: []kubevirtv1.VirtualMachineInstanceNetworkInterface{
 							{
-								Name:          "net0",
-								InterfaceName: "eth0",
-								IPs:           []string{"192.168.178.64/24", "fe80::21f:bcff:fe13:405/64"},
+								Name:          networkName0,
+								InterfaceName: interfaceName0,
+								IPs:           []string{ipv4Address0, linkLocalIPv60},
 							},
 							{
-								Name:          "net1",
+								Name:          networkName1,
 								InterfaceName: "eth1",
 								IPs:           []string{"fe80::21f:bcff:fe13:406/64"},
 							},
 							{
-								Name:          "net2",
+								Name:          networkName2,
 								InterfaceName: "eth2",
-								IPs:           []string{"192.168.180.64/24", "169.254.180.64/24", "201.168.180.64/24"},
+								IPs:           []string{ipv4Address1, "169.254.180.64/24", "201.168.180.64/24"},
 							},
 						},
 					},
@@ -273,18 +283,18 @@ func TestNetworkInterface(t *testing.T) {
 			},
 			expectation: []map[string]interface{}{
 				{
-					constants.FieldNetworkInterfaceName:          "net0",
+					constants.FieldNetworkInterfaceName:          networkName0,
 					constants.FieldNetworkInterfaceType:          builder.NetworkInterfaceTypeBridge,
 					constants.FieldNetworkInterfaceModel:         "",
 					constants.FieldNetworkInterfaceMACAddress:    "",
 					constants.FieldNetworkInterfaceNetworkName:   "",
 					constants.FieldNetworkInterfaceBootOrder:     &[]uint{1}[0],
 					constants.FieldNetworkInterfaceWaitForLease:  false,
-					constants.FieldNetworkInterfaceIPAddress:     "192.168.178.64/24",
-					constants.FieldNetworkInterfaceInterfaceName: "eth0",
+					constants.FieldNetworkInterfaceIPAddress:     ipv4Address0,
+					constants.FieldNetworkInterfaceInterfaceName: interfaceName0,
 				},
 				{
-					constants.FieldNetworkInterfaceName:         "net1",
+					constants.FieldNetworkInterfaceName:         networkName1,
 					constants.FieldNetworkInterfaceType:         builder.NetworkInterfaceTypeBridge,
 					constants.FieldNetworkInterfaceModel:        "",
 					constants.FieldNetworkInterfaceMACAddress:   "",
@@ -293,14 +303,14 @@ func TestNetworkInterface(t *testing.T) {
 					constants.FieldNetworkInterfaceWaitForLease: false,
 				},
 				{
-					constants.FieldNetworkInterfaceName:          "net2",
+					constants.FieldNetworkInterfaceName:          networkName2,
 					constants.FieldNetworkInterfaceType:          builder.NetworkInterfaceTypeBridge,
 					constants.FieldNetworkInterfaceModel:         "",
 					constants.FieldNetworkInterfaceMACAddress:    "",
 					constants.FieldNetworkInterfaceNetworkName:   "",
 					constants.FieldNetworkInterfaceBootOrder:     &[]uint{3}[0],
 					constants.FieldNetworkInterfaceWaitForLease:  false,
-					constants.FieldNetworkInterfaceIPAddress:     "192.168.180.64/24",
+					constants.FieldNetworkInterfaceIPAddress:     ipv4Address1,
 					constants.FieldNetworkInterfaceInterfaceName: "eth2",
 				},
 			},
@@ -321,7 +331,7 @@ func TestNetworkInterface(t *testing.T) {
 									Devices: kubevirtv1.Devices{
 										Interfaces: []kubevirtv1.Interface{
 											{
-												Name: "net0",
+												Name: networkName0,
 												InterfaceBindingMethod: kubevirtv1.InterfaceBindingMethod{
 													Bridge: &kubevirtv1.InterfaceBridge{},
 												},
@@ -338,9 +348,9 @@ func TestNetworkInterface(t *testing.T) {
 					Status: kubevirtv1.VirtualMachineInstanceStatus{
 						Interfaces: []kubevirtv1.VirtualMachineInstanceNetworkInterface{
 							{
-								Name:          "net0",
-								InterfaceName: "eth0",
-								IPs:           []string{"201.168.180.64/24", "169.254.180.64/24", "192.168.180.64/24"},
+								Name:          networkName0,
+								InterfaceName: interfaceName0,
+								IPs:           []string{"201.168.180.64/24", "169.254.180.64/24", ipv4Address1},
 							},
 						},
 					},
@@ -348,15 +358,15 @@ func TestNetworkInterface(t *testing.T) {
 			},
 			expectation: []map[string]interface{}{
 				{
-					constants.FieldNetworkInterfaceName:          "net0",
+					constants.FieldNetworkInterfaceName:          networkName0,
 					constants.FieldNetworkInterfaceType:          builder.NetworkInterfaceTypeBridge,
 					constants.FieldNetworkInterfaceModel:         "",
 					constants.FieldNetworkInterfaceMACAddress:    "",
 					constants.FieldNetworkInterfaceNetworkName:   "",
 					constants.FieldNetworkInterfaceBootOrder:     &[]uint{1}[0],
 					constants.FieldNetworkInterfaceWaitForLease:  false,
-					constants.FieldNetworkInterfaceIPAddress:     "192.168.180.64/24",
-					constants.FieldNetworkInterfaceInterfaceName: "eth0",
+					constants.FieldNetworkInterfaceIPAddress:     ipv4Address1,
+					constants.FieldNetworkInterfaceInterfaceName: interfaceName0,
 				},
 			},
 			expectError: nil,


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:

We already bumped go to 1.26 in v1.8 branch, see https://github.com/harvester/terraform-provider-harvester/commit/5f45f6dc758faf21adab877eec3c5160e4ee985c. However, master branch and v1.9 somehow missed this change.

#### Solution:

Bump golang to 1.26, also fixed the goconst linter error: this pr bumped golangci-lint to the corresponding version `2.12.2` which includes goconst v1.10.0 (back then golangci-lint version was v2.8.0 which has goconst version v1.8.2 included):
And since goconst v1.9.0, it detect repeated literals inside composite literal elements:
- direct literal elements like []string{"x"}
- keyed elements like map[string]string{"k":"v"} and struct{...}{Field: "x"}
see https://github.com/jgautheron/goconst/commit/6a821053e8ef2a592cb719700c7e6c7f304fdd8b for more details.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/10725
https://github.com/harvester/harvester/issues/11501

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
