### PR TITLE
deps: remove k8s.io/utils dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,6 @@ require (
 	k8s.io/api v0.34.1
 	k8s.io/apimachinery v0.34.1
 	k8s.io/client-go v12.0.0+incompatible
-	k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d
 	kubevirt.io/api v1.7.0
 )
 
@@ -219,6 +218,7 @@ require (
 	k8s.io/kube-aggregator v0.33.1 // indirect
 	k8s.io/kube-openapi v0.32.8 // indirect
 	k8s.io/kubernetes v1.34.2 // indirect
+	k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d // indirect
 	kubevirt.io/client-go v1.7.0 // indirect
 	kubevirt.io/containerized-data-importer-api v1.64.0 // indirect
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4 // indirect

--- a/internal/provider/virtualmachine/resource_virtualmachine.go
+++ b/internal/provider/virtualmachine/resource_virtualmachine.go
@@ -14,7 +14,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/harvester/terraform-provider-harvester/internal/config"
@@ -332,7 +331,7 @@ func createInitialSnapshot(ctx context.Context, c *client.Client, namespace, vmN
 		},
 		Spec: harvsterv1.VirtualMachineBackupSpec{
 			Source: corev1.TypedLocalObjectReference{
-				APIGroup: ptr.To(kubevirtv1.SchemeGroupVersion.Group),
+				APIGroup: new(kubevirtv1.SchemeGroupVersion.Group),
 				Kind:     kubevirtv1.VirtualMachineGroupVersionKind.Kind,
 				Name:     vmName,
 			},

--- a/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
+++ b/internal/provider/virtualmachine/resource_virtualmachine_constructor.go
@@ -9,7 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/harvester/harvester/pkg/builder"
@@ -104,7 +103,7 @@ func (c *Constructor) Setup() util.Processors {
 					firmware = &kubevirtv1.Firmware{
 						Bootloader: &kubevirtv1.Bootloader{
 							EFI: &kubevirtv1.EFI{
-								SecureBoot: ptr.To(false),
+								SecureBoot: new(false),
 							},
 						},
 					}
@@ -128,7 +127,7 @@ func (c *Constructor) Setup() util.Processors {
 				if firmware == nil || firmware.Bootloader == nil || firmware.Bootloader.EFI == nil {
 					return errors.New("EFI must be enabled to use Secure Boot. ")
 				}
-				firmware.Bootloader.EFI.SecureBoot = ptr.To(true)
+				firmware.Bootloader.EFI.SecureBoot = new(true)
 				vmBuilder.VirtualMachine.Spec.Template.Spec.Domain.Firmware = firmware
 
 				features := vmBuilder.VirtualMachine.Spec.Template.Spec.Domain.Features
@@ -136,7 +135,7 @@ func (c *Constructor) Setup() util.Processors {
 					features = &kubevirtv1.Features{}
 				}
 				features.SMM = &kubevirtv1.FeatureState{
-					Enabled: ptr.To(true),
+					Enabled: new(true),
 				}
 				vmBuilder.VirtualMachine.Spec.Template.Spec.Domain.Features = features
 				return nil
@@ -306,7 +305,7 @@ func (c *Constructor) Setup() util.Processors {
 							}
 						}
 					}
-					pvcOption.StorageClassName = ptr.To(storageClassName)
+					pvcOption.StorageClassName = new(storageClassName)
 
 					if volumeMode := r[constants.FieldVolumeMode].(string); volumeMode != "" {
 						pvcOption.VolumeMode = corev1.PersistentVolumeMode(volumeMode)

--- a/internal/provider/volume/resource_volume_constructor.go
+++ b/internal/provider/volume/resource_volume_constructor.go
@@ -6,7 +6,6 @@ import (
 	"github.com/harvester/harvester/pkg/builder"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/utils/ptr"
 
 	"github.com/harvester/terraform-provider-harvester/internal/util"
 	"github.com/harvester/terraform-provider-harvester/pkg/constants"
@@ -74,7 +73,7 @@ func (c *Constructor) Setup() util.Processors {
 				}
 				c.Volume.Annotations[builder.AnnotationKeyImageID] = helper.BuildNamespacedName(imageNamespace, imageName)
 				storageClassName := builder.BuildImageStorageClassName("", imageName)
-				c.Volume.Spec.StorageClassName = ptr.To(storageClassName)
+				c.Volume.Spec.StorageClassName = new(storageClassName)
 				return nil
 			},
 		},
@@ -85,7 +84,7 @@ func (c *Constructor) Setup() util.Processors {
 				if c.Volume.Annotations[builder.AnnotationKeyImageID] != "" && c.Volume.Spec.StorageClassName != nil && storageClassName != *c.Volume.Spec.StorageClassName {
 					return fmt.Errorf("the %s of an image can only be defined during image creation", constants.FieldVolumeStorageClassName)
 				} else {
-					c.Volume.Spec.StorageClassName = ptr.To(storageClassName)
+					c.Volume.Spec.StorageClassName = new(storageClassName)
 				}
 				return nil
 			},


### PR DESCRIPTION
Since Golang v1.26 the builtin `new()` accepts value expressions. This is functionally equivalent to `ptr.To()` from the k8s.io/utils library. Therefore the dependency on the k8s.io/utils library can be removed as the only use of this library in the code base was `ptr.To()`.

#### Problem:

Unnecessary dependency on external library.

#### Solution:

Replace uses of `ptr.To()` with Golang builtin `new()`. This makes the import of the library superfluous.

#### Related Issue(s):

N/A

#### Test plan:

N/A. No functional changes.

#### Additional documentation or context
